### PR TITLE
remove dependency to guava in code

### DIFF
--- a/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
@@ -1,8 +1,6 @@
 package io.swagger.codegen.languages;
 
 import com.github.jknack.handlebars.Handlebars;
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 import com.samskivert.mustache.Mustache;
 import io.swagger.codegen.CliOption;
 import io.swagger.codegen.CodegenConfig;
@@ -63,6 +61,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -2881,13 +2880,9 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
      * @return camelized string
      */
     protected String removeNonNameElementToCamelCase(final String name, final String nonNameElementPattern) {
-        String result = StringUtils.join(Lists.transform(Lists.newArrayList(name.split(nonNameElementPattern)), new Function<String, String>() {
-            @Nullable
-            @Override
-            public String apply(String input) {
-                return StringUtils.capitalize(input);
-            }
-        }), "");
+        String result = Arrays.stream(name.split(nonNameElementPattern))
+                .map(StringUtils::capitalize)
+                .collect(Collectors.joining(""));
         if (result.length() > 0) {
             result = result.substring(0, 1).toLowerCase() + result.substring(1);
         }

--- a/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
@@ -1,7 +1,6 @@
 package io.swagger.codegen.languages.java;
 
 import com.github.jknack.handlebars.Handlebars;
-import com.google.common.base.Strings;
 import io.swagger.codegen.CliOption;
 import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenModel;
@@ -1095,7 +1094,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
     private static String sanitizePackageName(String packageName) {
         packageName = packageName.trim(); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         packageName = packageName.replaceAll("[^a-zA-Z0-9_\\.]", "_");
-        if(Strings.isNullOrEmpty(packageName)) {
+        if(packageName == null || packageName.isEmpty()) {
             return "invalidPackageName";
         }
         return packageName;


### PR DESCRIPTION
This is a possible fix for #5.

With this change, the java code no longer uses guava. Imports of following classes are removed:

* `com.google.common.base.Function`
* `com.google.common.collect.Lists`
* `com.google.common.base.Strings`

This change do not compile on my machine, because other changes occured in the SNAPSHOT libraries referenced as dependency.

In oder to verify my change, I had to switch back to the same released versions as with release `1.0.0-rc0`, properties:

```
<swagger-parser-version>2.0.0-rc3</swagger-parser-version>
<swagger-core-version>2.0.0-rc4</swagger-core-version>
<swagger-codegen-version>3.0.0-rc0</swagger-codegen-version>
```

Changing the versions is not a solution that should be commited to the master branch. The code needs to be changed to work with the lattest SNAPSHOT versions
