### PR TITLE
Consistent handling of templateVersion

### DIFF
--- a/src/main/java/io/swagger/codegen/languages/java/JavaInflectorServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/JavaInflectorServerCodegen.java
@@ -35,7 +35,6 @@ public class JavaInflectorServerCodegen extends AbstractJavaCodegen {
         super();
         sourceFolder = "src/gen/java";
         apiTestTemplateFiles.clear(); // TODO: add test template
-        embeddedTemplateDir = templateDir = String.format("%s/JavaInflector", DEFAULT_TEMPLATE_VERSION);
         invokerPackage = "io.swagger.controllers";
         artifactId = "swagger-inflector-server";
         dateLibrary = "legacy"; //TODO: add joda support
@@ -83,6 +82,8 @@ public class JavaInflectorServerCodegen extends AbstractJavaCodegen {
         String templateVersion = getTemplateVersion();
         if (StringUtils.isNotBlank(templateVersion)) {
             embeddedTemplateDir = templateDir = String.format("%s/JavaInflector", templateVersion);
+        } else {
+            embeddedTemplateDir = templateDir = String.format("%s/JavaInflector", DEFAULT_TEMPLATE_VERSION);
         }
         writeOptional(outputFolder, new SupportingFile("pom.mustache", "", "pom.xml"));
         writeOptional(outputFolder, new SupportingFile("README.mustache", "", "README.md"));


### PR DESCRIPTION
On master when I try to generate a java client I get this error:

```
Exception in thread "main" java.lang.RuntimeException: Could not generate api file for 'Default'
	at io.swagger.codegen.DefaultGenerator.generateApis(DefaultGenerator.java:525)
	at io.swagger.codegen.DefaultGenerator.generate(DefaultGenerator.java:729)
	at <my class>.convertExample(<my class>.java:82)
Caused by: java.io.FileNotFoundException: /null/JavaInflector/api.mustache
	at com.github.jknack.handlebars.io.URLTemplateLoader.sourceAt(URLTemplateLoader.java:70)
	at com.github.jknack.handlebars.Handlebars.compile(Handlebars.java:357)
	at com.github.jknack.handlebars.Handlebars.compile(Handlebars.java:343)
	at io.swagger.codegen.DefaultGenerator.getHandlebars(DefaultGenerator.java:1019)
	at io.swagger.codegen.DefaultGenerator.processTemplateToFile(DefaultGenerator.java:742)
	at io.swagger.codegen.DefaultGenerator.generateApis(DefaultGenerator.java:484)
	... 3 more
```

I did a review of commit d27181ffaa70bbd5f382e0b3013f150f363497bb and I propose following changes.

* If no version is set: `DefaultCodegenConfig` needs to set the `templateVersion` to `DEFAULT_TEMPLATE_VERSION`
* `JavaClientCodegen` and `JavaInflectorServerCodegen` uses `templateVersion` the same way.
* Unnecessary code is removed.