### PR TITLE
Add getLanguageArguments() in DefaultCodegenConfig

### DIFF
--- a/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
@@ -3,6 +3,7 @@ package io.swagger.codegen.languages;
 import com.github.jknack.handlebars.Handlebars;
 import com.samskivert.mustache.Mustache;
 import io.swagger.codegen.CliOption;
+import io.swagger.codegen.CodegenArgument;
 import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenModel;
@@ -3242,6 +3243,11 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         handlebars.registerHelper(HasHelper.NAME, new HasHelper());
         handlebars.registerHelper(IsNotHelper.NAME, new IsNotHelper());
         handlebars.registerHelper(HasNotHelper.NAME, new HasNotHelper());
+    }
+
+    @Override
+    public List<CodegenArgument> getLanguageArguments() {
+        return null;
     }
 
     /**


### PR DESCRIPTION
`getLanguageArguments()` was  introduced in the `io.swagger.codegen.CodegenConfig` interface

See https://github.com/swagger-api/swagger-codegen/commit/f40c469b8be3d7913543d179badf3339827f1ec2