### PR TITLE
Fix collection-fomat query param datetype templates

### DIFF
--- a/src/main/resources/v2/Java/libraries/retrofit/queryParams.mustache
+++ b/src/main/resources/v2/Java/libraries/retrofit/queryParams.mustache
@@ -1,1 +1,1 @@
-{{#is this 'query-param'}}@retrofit.http.Query("{{baseName}}") {{#if collectionFormat}}{{#is this 'collection-format-multi'}}{{{dataType}}}{{/is}}{{#isNot this 'collection-format-multi'}}{{{collectionFormat.toUpperCase}}}Params{{/isNot}}{{else}}{{{dataType}}}{{/if}} {{paramName}}{{/is}}
+{{#is this 'query-param'}}@retrofit.http.Query("{{baseName}}") {{{dataType}}} {{paramName}}{{/is}}

--- a/src/main/resources/v2/Java/libraries/retrofit2/queryParams.mustache
+++ b/src/main/resources/v2/Java/libraries/retrofit2/queryParams.mustache
@@ -1,1 +1,1 @@
-{{#is this 'query-param'}}@retrofit2.http.Query("{{baseName}}") {{#if collectionFormat}}{{#is this 'collection-format-multi'}}{{{dataType}}}{{/is}}{{#isNot this 'collection-format-multi'}}{{{collectionFormat.toUpperCase}}}Params{{/isNot}}{{else}}{{{dataType}}}{{/if}} {{paramName}}{{/is}}
+{{#is this 'query-param'}}@retrofit2.http.Path("{{baseName}}") {{{dataType}}} {{paramName}}{{/is}}


### PR DESCRIPTION
As explained in https://github.com/swagger-api/swagger-codegen-generators/issues/20, collection-fomat query param template rendering failed for retrofit 1 & 2.

I don't knw if it's the good solution.
I just make queryParam templates work (because it's not the case so far) but I don't know if it's the good/best solution.

In another issue (https://github.com/swagger-api/swagger-codegen/issues/6504), they'd prefer to improve "pathParam" template to manage much more cases.