### PR TITLE
Add Codegen classes the CodegenConfig service registry

### DIFF
--- a/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
+++ b/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
@@ -1,0 +1,2 @@
+io.swagger.codegen.languages.java.JavaClientCodegen
+io.swagger.codegen.languages.java.JavaInflectorServerCodegen


### PR DESCRIPTION
As indicated in https://github.com/swagger-api/swagger-codegen/pull/7710, the two Codegen classes `java` and `inflector` needs to be defined in a service registery in this jar.