### PR TITLE
Fixes in JaxRS

### DIFF
--- a/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
@@ -508,7 +508,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
     @Override
     public String toVarName(String name) {
         // sanitize name
-        name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
+        name = sanitizeVarName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
         if (name.toLowerCase().matches("^_*class$")) {
             return "propertyClass";
@@ -584,7 +584,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
             return importMapping.get(name);
         }
 
-        final String sanitizedName = super.sanitizeName(name);
+        final String sanitizedName = sanitizeName(name);
 
         String nameWithPrefixSuffix = sanitizedName;
         if (!StringUtils.isEmpty(modelNamePrefix)) {
@@ -1058,8 +1058,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         return op;
     }
 
-    @Override
-    public String sanitizeName(String name) {
+    public String sanitizeVarName(String name) {
         if (name == null) {
             LOGGER.warn("String to be sanitized is null. Default to " + Object.class.getSimpleName());
             return Object.class.getSimpleName();

--- a/src/main/resources/v2/JavaJaxRS/apiService.mustache
+++ b/src/main/resources/v2/JavaJaxRS/apiService.mustache
@@ -8,6 +8,7 @@ import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 {{#imports}}import {{import}};
 {{/imports}}
 
+import java.util.Map;
 import java.util.List;
 import {{package}}.NotFoundException;
 

--- a/src/main/resources/v2/JavaJaxRS/apiServiceImpl.mustache
+++ b/src/main/resources/v2/JavaJaxRS/apiServiceImpl.mustache
@@ -6,6 +6,7 @@ import {{modelPackage}}.*;
 {{#imports}}import {{import}};
 {{/imports}}
 
+import java.util.Map;
 import java.util.List;
 import {{package}}.NotFoundException;
 

--- a/src/main/resources/v2/JavaJaxRS/pojo.mustache
+++ b/src/main/resources/v2/JavaJaxRS/pojo.mustache
@@ -115,7 +115,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{#has this 'more'}}, {{/has}}{{/vars}}{{#parent}}{{#has this 'vars'}}, {{/has}}super.hashCode(){{/parent}});
+    return Objects.hash({{#vars}}{{name}}{{#has this 'more'}}, {{/has}}{{/vars}}{{#parentModel}}{{#has this 'vars'}}, {{/has}}super.hashCode(){{/parentModel}});
   }
 
 {{/supportJava6}}
@@ -137,7 +137,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   @Override
   public int hashCode() {
-    return ObjectUtils.hashCodeMulti({{#vars}}{{name}}{{#has this 'more'}}, {{/has}}{{/vars}}{{#parent}}{{#has this 'vars'}}, {{/has}}super.hashCode(){{/parent}});
+    return ObjectUtils.hashCodeMulti({{#vars}}{{name}}{{#has this 'more'}}, {{/has}}{{/vars}}{{#parentModel}}{{#has this 'vars'}}, {{/has}}super.hashCode(){{/parentModel}});
   }
 
 {{/supportJava6}}

--- a/src/test/java/io/swagger/codegen/languages/java/AbstractJavaCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/languages/java/AbstractJavaCodegenTest.java
@@ -112,13 +112,20 @@ public class AbstractJavaCodegenTest {
 
     @Test
      public void convertVarName() throws Exception {
-        AbstractJavaCodegen codegen = new JavaClientCodegen();
-        Assert.assertEquals(codegen.toVarName("name"), "name");
-        Assert.assertEquals(codegen.toVarName("$name"), "$name");
-        Assert.assertEquals(codegen.toVarName("nam$$e"), "nam$$e");
-        Assert.assertEquals(codegen.toVarName("_name"), "_name");
-        Assert.assertEquals(codegen.toVarName("user-name"), "userName");
-        Assert.assertEquals(codegen.toVarName("user_name"), "userName");
-        Assert.assertEquals(codegen.toVarName("_user_name"), "_userName");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("name"), "name");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("$name"), "$name");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("nam$$e"), "nam$$e");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("_name"), "_name");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("user-name"), "userName");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("user_name"), "userName");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("_user_name"), "_userName");
+    }
+
+    @Test
+    public void convertModelName() throws Exception {
+        Assert.assertEquals(fakeJavaCodegen.toModelName("name"), "Name");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("$name"), "Name");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("nam#e"), "Name");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("$another-fake?"), "AnotherFake");
     }
 }

--- a/src/test/java/io/swagger/codegen/languages/java/AbstractJavaJAXRSServerCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/languages/java/AbstractJavaJAXRSServerCodegenTest.java
@@ -1,0 +1,46 @@
+package io.swagger.codegen.languages.java;
+
+import io.swagger.codegen.CodegenArgument;
+import io.swagger.codegen.CodegenType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.util.List;
+
+public class AbstractJavaJAXRSServerCodegenTest {
+
+    private final AbstractJavaJAXRSServerCodegen fakeJavaJAXRSCodegen = new AbstractJavaJAXRSServerCodegen() {
+        @Override
+        public String getArgumentsLocation() {
+            return null;
+        }
+
+        @Override
+        public CodegenType getTag() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getHelp() {
+            return null;
+        }
+
+        @Override
+        public List<CodegenArgument> readLanguageArguments() {
+            return null;
+        }
+    };
+
+    @Test
+    public void convertApiName() throws Exception {
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("name"), "NameApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("$name"), "NameApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("nam#e"), "NameApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("$another-fake?"), "AnotherFakeApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("fake_classname_tags 123#$%^"), "FakeClassnameTags123Api");
+    }
+}


### PR DESCRIPTION
As discussed in #29, additional fixes needs to be made in order to fix the jaxrs test suite in the `swagger-codegen` repository (see also https://github.com/swagger-api/swagger-codegen/pull/7781)