### PR TITLE
Migrate {{#isInteger}}, {{#isLong}}, {{#isDouble}}, {{#isFloat}}

### DIFF
--- a/src/main/resources/v2/JavaJaxRS/cxf/enumClass.mustache
+++ b/src/main/resources/v2/JavaJaxRS/cxf/enumClass.mustache
@@ -3,7 +3,7 @@
 public enum {{datatypeWithEnum}} {
 
     {{#allowableValues}}
-{{#enumVars}}@XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}) {{name}}({{datatype}}.valueOf({{{value}}})){{^@last}}, {{/@last}}{{#@last}};{{/@last}}{{/enumVars}}
+{{#enumVars}}@XmlEnumValue({{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}}{{{value}}}{{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}}) {{name}}({{datatype}}.valueOf({{{value}}})){{^@last}}, {{/@last}}{{#@last}};{{/@last}}{{/enumVars}}
     {{/allowableValues}}
 
 

--- a/src/main/resources/v2/JavaJaxRS/cxf/enumOuterClass.mustache
+++ b/src/main/resources/v2/JavaJaxRS/cxf/enumOuterClass.mustache
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
   {{#if gson}}
   {{#allowableValues}}{{#enumVars}}
-  @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+  @SerializedName({{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}}{{{value}}}{{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}})
   {{{name}}}({{{value}}}){{^@last}},
   {{/@last}}{{#@last}};{{/@last}}{{/enumVars}}{{/allowableValues}}
   {{/if}}

--- a/src/main/resources/v2/JavaJaxRS/enumClass.mustache
+++ b/src/main/resources/v2/JavaJaxRS/enumClass.mustache
@@ -5,7 +5,7 @@
     {{#if gson}}
         {{#allowableValues}}
             {{#enumVars}}
-    @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+    @SerializedName({{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}}{{{value}}}{{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}})
     {{{name}}}({{{value}}}){{^@last}},
     {{/@last}}{{#@last}};{{/@last}}
             {{/enumVars}}

--- a/src/main/resources/v2/JavaJaxRS/enumOuterClass.mustache
+++ b/src/main/resources/v2/JavaJaxRS/enumOuterClass.mustache
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
   {{#if gson}}
   {{#allowableValues}}{{#enumVars}}
-  @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+  @SerializedName({{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}}{{{value}}}{{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}})
   {{{name}}}({{{value}}}){{^@last}},
   {{/@last}}{{#@last}};{{/@last}}{{/enumVars}}{{/allowableValues}}
   {{/if}}

--- a/src/main/resources/v2/JavaJaxRS/modelEnum.mustache
+++ b/src/main/resources/v2/JavaJaxRS/modelEnum.mustache
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
   {{#if gson}}
   {{#allowableValues}}{{#enumVars}}
-  @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+  @SerializedName({{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}}{{{value}}}{{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}})
   {{{name}}}({{{value}}}){{^@last}},
   {{/@last}}{{#@last}};{{/@last}}{{/enumVars}}{{/allowableValues}}
   {{/if}}

--- a/src/main/resources/v2/JavaJaxRS/spec/enumOuterClass.mustache
+++ b/src/main/resources/v2/JavaJaxRS/spec/enumOuterClass.mustache
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
   {{#if gson}}
   {{#allowableValues}}{{#enumVars}}
-  @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+  @SerializedName({{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}}{{{value}}}{{#is ../../this 'integer'}}"{{/is}}{{#is ../../this 'double'}}"{{/is}}{{#is ../../this 'long'}}"{{/is}}{{#is ../../this 'float'}}"{{/is}})
   {{{name}}}({{{value}}}){{^@last}},
   {{/@last}}{{#@last}};{{/@last}}{{/enumVars}}{{/allowableValues}}
   {{/if}}


### PR DESCRIPTION
Fix generated code: example [EnumTest.java Line 59 on master branch](https://github.com/swagger-api/swagger-codegen/blob/master/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/EnumTest.java#L59)

IS:
```
@XmlEnumValue(1) NUMBER_1(Integer.valueOf(1))
```

SHOULD BE:
```
@XmlEnumValue("1") NUMBER_1(Integer.valueOf(1))
```
---

This pull request migrates following:
* `{{#isInteger}} ... {{/isInteger}}`
* `{{#isLong}} ... {{/isLong}}`
* `{{#isDouble}} ... {{/isDouble}}`
* `{{#isFloat}} ... {{/isFloat}}`

Inside `{{#enumVars}}..{{/enumVars}}` 
