### PR TITLE
Remove fields declaration hiding another field or variable

### DIFF
--- a/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
@@ -86,16 +86,16 @@ import static io.swagger.codegen.CodegenConstants.HAS_OPTIONAL_EXT_NAME;
 import static io.swagger.codegen.CodegenConstants.HAS_REQUIRED_EXT_NAME;
 import static io.swagger.codegen.CodegenConstants.IS_ARRAY_MODEL_EXT_NAME;
 import static io.swagger.codegen.CodegenConstants.IS_ENUM_EXT_NAME;
+import static io.swagger.codegen.handlebars.helpers.ExtensionHelper.getBooleanValue;
 import static io.swagger.codegen.languages.CodegenHelper.getDefaultIncludes;
 import static io.swagger.codegen.languages.CodegenHelper.getImportMappings;
 import static io.swagger.codegen.languages.CodegenHelper.getTypeMappings;
 import static io.swagger.codegen.languages.CodegenHelper.initalizeSpecialCharacterMapping;
-import static io.swagger.codegen.handlebars.helpers.ExtensionHelper.getBooleanValue;
 import static io.swagger.codegen.utils.ModelUtils.processCodegenModels;
 
 public abstract class DefaultCodegenConfig implements CodegenConfig {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCodegenConfig.class);
 
-    protected static final Logger LOGGER = LoggerFactory.getLogger(DefaultCodegenConfig.class);
     public static final String DEFAULT_CONTENT_TYPE = "application/json";
     public static final String REQUEST_BODY_NAME = "body";
     public static final String DEFAULT_TEMPLATE_VERSION = "v2";

--- a/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
@@ -7,8 +7,8 @@ import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenOperation;
 import io.swagger.codegen.CodegenParameter;
 import io.swagger.codegen.CodegenProperty;
-import io.swagger.codegen.languages.DefaultCodegenConfig;
 import io.swagger.codegen.handlebars.helpers.JavaHelper;
+import io.swagger.codegen.languages.DefaultCodegenConfig;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
@@ -40,7 +40,7 @@ import static io.swagger.codegen.CodegenConstants.IS_ENUM_EXT_NAME;
 import static io.swagger.codegen.handlebars.helpers.ExtensionHelper.getBooleanValue;
 
 public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
-    static Logger LOGGER = LoggerFactory.getLogger(AbstractJavaCodegen.class);
+    private static Logger LOGGER = LoggerFactory.getLogger(AbstractJavaCodegen.class);
     public static final String FULL_JAVA_UTIL = "fullJavaUtil";
     public static final String DEFAULT_LIBRARY = "<default>";
     public static final String DATE_LIBRARY = "dateLibrary";
@@ -75,13 +75,13 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
     protected String javaUtilPrefix = "";
     protected Boolean serializableModel = false;
     protected boolean serializeBigDecimalAsString = false;
-    protected boolean hideGenerationTimestamp = false;
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
     protected boolean supportJava6= false;
 
     public AbstractJavaCodegen() {
         super();
+        hideGenerationTimestamp = false;
         supportsInheritance = true;
 
         setReservedWordsLowerCase(

--- a/src/main/java/io/swagger/codegen/languages/java/AbstractJavaJAXRSServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/AbstractJavaJAXRSServerCodegen.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import static io.swagger.codegen.languages.helpers.ExtensionHelper.getBooleanValue;
 
 public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen implements BeanValidationFeatures {
+    private static Logger LOGGER = LoggerFactory.getLogger(AbstractJavaJAXRSServerCodegen.class);
+
     /**
      * Name of the sub-directory in "src/main/resource" where to find the
      * Mustache template for the JAX-RS Codegen.
@@ -33,8 +35,6 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
     protected String title = "Swagger Server";
 
     protected boolean useBeanValidation = true;
-
-    static Logger LOGGER = LoggerFactory.getLogger(AbstractJavaJAXRSServerCodegen.class);
 
     public AbstractJavaJAXRSServerCodegen() {
         super();

--- a/src/main/java/io/swagger/codegen/languages/java/JavaJAXRSCXFCDIServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/JavaJAXRSCXFCDIServerCodegen.java
@@ -17,12 +17,11 @@ import java.io.File;
  */
 public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen implements BeanValidationFeatures {
 
-    protected boolean useBeanValidation = true;
-
     /**
      * Default constructor
      */
     public JavaJAXRSCXFCDIServerCodegen() {
+        useBeanValidation = true;
         outputFolder = "generated-code/JavaJaxRS-CXF-CDI";
         artifactId = "swagger-jaxrs-cxf-cdi-server";
         sourceFolder = "src" + File.separator + "gen" + File.separator + "java";

--- a/src/main/java/io/swagger/codegen/languages/java/JavaJerseyServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/JavaJerseyServerCodegen.java
@@ -23,9 +23,9 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
     protected static final String LIBRARY_JERSEY2 = "jersey2";
 
     /**
-     * Default library template to use. (Default:{@value #DEFAULT_LIBRARY})
+     * Default library template to use. (Default:{@value #DEFAULT_JERSEY_LIBRARY})
      */
-    public static final String DEFAULT_LIBRARY = LIBRARY_JERSEY2;
+    public static final String DEFAULT_JERSEY_LIBRARY = LIBRARY_JERSEY2;
     public static final String USE_TAGS = "useTags";
 
     protected boolean useTags = false;
@@ -40,7 +40,7 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
         supportedLibraries.put(LIBRARY_JERSEY1, "Jersey core 1.x");
         supportedLibraries.put(LIBRARY_JERSEY2, "Jersey core 2.x");
         library.setEnum(supportedLibraries);
-        library.setDefault(DEFAULT_LIBRARY);
+        library.setDefault(DEFAULT_JERSEY_LIBRARY);
 
         cliOptions.add(library);
         cliOptions.add(CliOption.newBoolean(SUPPORT_JAVA6, "Whether to support Java6 with the Jersey1/2 library."));
@@ -100,7 +100,7 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
 
         // use default library if unset
         if (StringUtils.isEmpty(library)) {
-            setLibrary(DEFAULT_LIBRARY);
+            setLibrary(DEFAULT_JERSEY_LIBRARY);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.IMPL_FOLDER)) {

--- a/src/main/java/io/swagger/codegen/languages/java/JavaResteasyEapServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/JavaResteasyEapServerCodegen.java
@@ -22,13 +22,13 @@ import static io.swagger.codegen.languages.helpers.ExtensionHelper.getBooleanVal
 
 public class JavaResteasyEapServerCodegen extends AbstractJavaJAXRSServerCodegen implements JbossFeature, BeanValidationFeatures, SwaggerFeatures {
 
-    protected boolean useBeanValidation = true;
     protected boolean generateJbossDeploymentDescriptor = true;
     protected boolean useSwaggerFeature = false;
 
     public JavaResteasyEapServerCodegen() {
-
         super();
+
+        useBeanValidation = true;
 
         artifactId = "swagger-jaxrs-resteasy-eap-server";
 


### PR DESCRIPTION
Having field declarations that hides another field or variable is in my opinion a bad practice in java. Name shadowing can cause subtle errors and should be avoided.

With this pull request, I propose to clean-up the code.
