### PR TITLE
Allow some values to be use in templates

### DIFF
--- a/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
@@ -166,23 +166,23 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
 
         if (additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE)) {
             this.setModelPackage((String) additionalProperties.get(CodegenConstants.MODEL_PACKAGE));
-        } else {
-            // not set, use to be passed to template
+        } else if (StringUtils.isNotEmpty(modelPackage)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.MODEL_PACKAGE, modelPackage);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.API_PACKAGE)) {
             this.setApiPackage((String) additionalProperties.get(CodegenConstants.API_PACKAGE));
-        } else {
-            // not set, use to be passed to template
+        } else if (StringUtils.isNotEmpty(apiPackage)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG)) {
             this.setSortParamsByRequiredFlag(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG).toString()));
-        } else {
-            // not set, use to be passed to template
+        } else if (sortParamsByRequiredFlag != null) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, sortParamsByRequiredFlag);
         }
 
@@ -212,8 +212,8 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         if (additionalProperties.containsKey(CodegenConstants.HIDE_GENERATION_TIMESTAMP)) {
             this.setHideGenerationTimestamp(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.HIDE_GENERATION_TIMESTAMP).toString()));
-        } else {
-            //not set, use to be passed to template
+        } else if(hideGenerationTimestamp != null) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, hideGenerationTimestamp);
         }
     }

--- a/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
@@ -166,15 +166,24 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
 
         if (additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE)) {
             this.setModelPackage((String) additionalProperties.get(CodegenConstants.MODEL_PACKAGE));
+        } else {
+            // not set, use to be passed to template
+            additionalProperties.put(CodegenConstants.MODEL_PACKAGE, modelPackage);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.API_PACKAGE)) {
             this.setApiPackage((String) additionalProperties.get(CodegenConstants.API_PACKAGE));
+        } else {
+            // not set, use to be passed to template
+            additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG)) {
             this.setSortParamsByRequiredFlag(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG).toString()));
+        } else {
+            // not set, use to be passed to template
+            additionalProperties.put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, sortParamsByRequiredFlag);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.ENSURE_UNIQUE_PARAMS)) {
@@ -196,7 +205,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         }
 
         if (additionalProperties.containsKey(CodegenConstants.REMOVE_OPERATION_ID_PREFIX)) {
-            this.setSortParamsByRequiredFlag(Boolean.valueOf(additionalProperties
+            this.setRemoveOperationIdPrefix(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.REMOVE_OPERATION_ID_PREFIX).toString()));
         }
     }

--- a/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
@@ -588,6 +588,10 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         this.apiPackage = apiPackage;
     }
 
+    public Boolean getSortParamsByRequiredFlag() {
+        return sortParamsByRequiredFlag;
+    }
+
     public void setSortParamsByRequiredFlag(Boolean sortParamsByRequiredFlag) {
         this.sortParamsByRequiredFlag = sortParamsByRequiredFlag;
     }

--- a/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
@@ -205,8 +205,16 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         }
 
         if (additionalProperties.containsKey(CodegenConstants.REMOVE_OPERATION_ID_PREFIX)) {
-            this.setRemoveOperationIdPrefix(Boolean.valueOf(additionalProperties
+            this.setSortParamsByRequiredFlag(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.REMOVE_OPERATION_ID_PREFIX).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.HIDE_GENERATION_TIMESTAMP)) {
+            this.setHideGenerationTimestamp(Boolean.valueOf(additionalProperties
+                    .get(CodegenConstants.HIDE_GENERATION_TIMESTAMP).toString()));
+        } else {
+            //not set, use to be passed to template
+            additionalProperties.put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, hideGenerationTimestamp);
         }
     }
 
@@ -3180,6 +3188,24 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
      */
     public String getHttpUserAgent() {
         return httpUserAgent;
+    }
+
+    /**
+     * Hide generation timestamp
+     *
+     * @param hideGenerationTimestamp flag to indicates if the generation timestamp should be hidden or not
+     */
+    public void setHideGenerationTimestamp(Boolean hideGenerationTimestamp) {
+        this.hideGenerationTimestamp = hideGenerationTimestamp;
+    }
+
+    /**
+     * Hide generation timestamp
+     *
+     * @return if the generation timestamp should be hidden or not
+     */
+    public Boolean getHideGenerationTimestamp() {
+        return hideGenerationTimestamp;
     }
 
     @SuppressWarnings("static-method")

--- a/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
@@ -160,9 +160,8 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
             this.setTemplateDir((String) additionalProperties.get(CodegenConstants.TEMPLATE_DIR));
         }
 
-        //todo: replace hardcore string for constant on "CodegenConstans" class once publishing issue on codegen be resolved. (02-15-18)
-        if (additionalProperties.containsKey(/**fixme: CodegenConstants.TEMPLATE_VERSION*/ "templateVersion")) {
-            this.setTemplateVersion((String) additionalProperties.get(/**fixme: CodegenConstants.TEMPLATE_VERSION*/ "templateVersion"));
+        if (additionalProperties.containsKey(CodegenConstants.TEMPLATE_VERSION)) {
+            this.setTemplateVersion((String) additionalProperties.get(CodegenConstants.TEMPLATE_VERSION));
         }
 
         if (additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE)) {

--- a/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
@@ -181,8 +181,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
             this.additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, derviedInvokerPackage);
             this.setInvokerPackage((String) additionalProperties.get(CodegenConstants.INVOKER_PACKAGE));
             LOGGER.info("Invoker Package Name, originally not set, is now dervied from model package name: " + derviedInvokerPackage);
-        } else {
-            //not set, use default to be passed to template
+        } else if (StringUtils.isNotEmpty(invokerPackage)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
         }
 
@@ -201,88 +201,99 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
 
         if (additionalProperties.containsKey(CodegenConstants.GROUP_ID)) {
             this.setGroupId((String) additionalProperties.get(CodegenConstants.GROUP_ID));
-        } else {
-            //not set, use to be passed to template
+        } else if(StringUtils.isNotEmpty(groupId)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.GROUP_ID, groupId);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.ARTIFACT_ID)) {
             this.setArtifactId((String) additionalProperties.get(CodegenConstants.ARTIFACT_ID));
-        } else {
-            //not set, use to be passed to template
+        } else if(StringUtils.isNotEmpty(artifactId)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.ARTIFACT_ID, artifactId);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.ARTIFACT_VERSION)) {
             this.setArtifactVersion((String) additionalProperties.get(CodegenConstants.ARTIFACT_VERSION));
-        } else {
-            //not set, use to be passed to template
+        } else if(StringUtils.isNotEmpty(artifactVersion)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.ARTIFACT_VERSION, artifactVersion);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.ARTIFACT_URL)) {
             this.setArtifactUrl((String) additionalProperties.get(CodegenConstants.ARTIFACT_URL));
-        } else {
+        } else if(StringUtils.isNoneEmpty(artifactUrl)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.ARTIFACT_URL, artifactUrl);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.ARTIFACT_DESCRIPTION)) {
             this.setArtifactDescription((String) additionalProperties.get(CodegenConstants.ARTIFACT_DESCRIPTION));
-        } else {
+        } else if(StringUtils.isNoneEmpty(artifactDescription)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.ARTIFACT_DESCRIPTION, artifactDescription);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SCM_CONNECTION)) {
             this.setScmConnection((String) additionalProperties.get(CodegenConstants.SCM_CONNECTION));
-        } else {
+        } else if(StringUtils.isNoneEmpty(scmConnection)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.SCM_CONNECTION, scmConnection);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SCM_DEVELOPER_CONNECTION)) {
             this.setScmDeveloperConnection((String) additionalProperties.get(CodegenConstants.SCM_DEVELOPER_CONNECTION));
-        } else {
+        } else if(StringUtils.isNoneEmpty(scmDeveloperConnection)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.SCM_DEVELOPER_CONNECTION, scmDeveloperConnection);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SCM_URL)) {
             this.setScmUrl((String) additionalProperties.get(CodegenConstants.SCM_URL));
-        } else {
+        } else if(StringUtils.isNoneEmpty(scmUrl)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.SCM_URL, scmUrl);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.DEVELOPER_NAME)) {
             this.setDeveloperName((String) additionalProperties.get(CodegenConstants.DEVELOPER_NAME));
-        } else {
+        } else if(StringUtils.isNoneEmpty(developerName)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.DEVELOPER_NAME, developerName);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.DEVELOPER_EMAIL)) {
             this.setDeveloperEmail((String) additionalProperties.get(CodegenConstants.DEVELOPER_EMAIL));
-        } else {
+        } else if(StringUtils.isNoneEmpty(developerEmail)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.DEVELOPER_EMAIL, developerEmail);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.DEVELOPER_ORGANIZATION)) {
             this.setDeveloperOrganization((String) additionalProperties.get(CodegenConstants.DEVELOPER_ORGANIZATION));
-        } else {
+        } else if(StringUtils.isNoneEmpty(developerOrganization)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.DEVELOPER_ORGANIZATION, developerOrganization);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.DEVELOPER_ORGANIZATION_URL)) {
             this.setDeveloperOrganizationUrl((String) additionalProperties.get(CodegenConstants.DEVELOPER_ORGANIZATION_URL));
-        } else {
+        } else if(StringUtils.isNoneEmpty(developerOrganizationUrl)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.DEVELOPER_ORGANIZATION_URL, developerOrganizationUrl);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.LICENSE_NAME)) {
             this.setLicenseName((String) additionalProperties.get(CodegenConstants.LICENSE_NAME));
-        } else {
+        } else if(StringUtils.isNoneEmpty(licenseName)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.LICENSE_NAME, licenseName);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.LICENSE_URL)) {
             this.setLicenseUrl((String) additionalProperties.get(CodegenConstants.LICENSE_URL));
-        } else {
+        } else if(StringUtils.isNoneEmpty(licenseUrl)) {
+            // not set in additionalProperties, add value from CodegenConfig in order to use it in templates
             additionalProperties.put(CodegenConstants.LICENSE_URL, licenseUrl);
         }
 

--- a/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
@@ -167,20 +167,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
 
     @Override
     public void processOpts() {
-        super.processOpts();
-
-        modelTemplateFiles.put("model.mustache", ".java");
-        apiTemplateFiles.put("api.mustache", ".java");
-        apiTestTemplateFiles.put("api_test.mustache", ".java");
-        modelDocTemplateFiles.put("model_doc.mustache", ".md");
-        apiDocTemplateFiles.put("api_doc.mustache", ".md");
-
-        if (additionalProperties.containsKey(SUPPORT_JAVA6)) {
-            this.setSupportJava6(Boolean.valueOf(additionalProperties.get(SUPPORT_JAVA6).toString()));
-        }
-        additionalProperties.put(SUPPORT_JAVA6, supportJava6);
-
-
         if (additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
             this.setInvokerPackage((String) additionalProperties.get(CodegenConstants.INVOKER_PACKAGE));
         } else if (additionalProperties.containsKey(CodegenConstants.API_PACKAGE)) {
@@ -199,6 +185,19 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
             //not set, use default to be passed to template
             additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
         }
+
+        super.processOpts();
+
+        modelTemplateFiles.put("model.mustache", ".java");
+        apiTemplateFiles.put("api.mustache", ".java");
+        apiTestTemplateFiles.put("api_test.mustache", ".java");
+        modelDocTemplateFiles.put("model_doc.mustache", ".md");
+        apiDocTemplateFiles.put("api_doc.mustache", ".md");
+
+        if (additionalProperties.containsKey(SUPPORT_JAVA6)) {
+            this.setSupportJava6(Boolean.valueOf(additionalProperties.get(SUPPORT_JAVA6).toString()));
+        }
+        additionalProperties.put(SUPPORT_JAVA6, supportJava6);
 
         if (additionalProperties.containsKey(CodegenConstants.GROUP_ID)) {
             this.setGroupId((String) additionalProperties.get(CodegenConstants.GROUP_ID));

--- a/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
@@ -143,7 +143,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         cliOptions.add(CliOption.newBoolean(CodegenConstants.SERIALIZE_BIG_DECIMAL_AS_STRING, CodegenConstants
                 .SERIALIZE_BIG_DECIMAL_AS_STRING_DESC));
         cliOptions.add(CliOption.newBoolean(FULL_JAVA_UTIL, "whether to use fully qualified name for classes under java.util. This option only works for Java API client"));
-        cliOptions.add(new CliOption("hideGenerationTimestamp", "hides the timestamp when files were generated"));
+        cliOptions.add(new CliOption(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.HIDE_GENERATION_TIMESTAMP_DESC));
         cliOptions.add(CliOption.newBoolean(WITH_XML, "whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)"));
 
         CliOption dateLibrary = new CliOption(DATE_LIBRARY, "Option. Date library to use");

--- a/src/main/java/io/swagger/codegen/languages/java/JavaClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/JavaClientCodegen.java
@@ -4,9 +4,7 @@ import static io.swagger.codegen.CodegenConstants.IS_ENUM_EXT_NAME;
 import static io.swagger.codegen.languages.helpers.ExtensionHelper.getBooleanValue;
 import static java.util.Collections.sort;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.codegen.CliOption;
-import io.swagger.codegen.CodegenArgument;
 import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenOperation;
@@ -18,23 +16,25 @@ import io.swagger.codegen.languages.features.BeanValidationFeatures;
 import io.swagger.codegen.languages.features.GzipFeatures;
 import io.swagger.codegen.languages.features.PerformBeanValidationFeatures;
 
-import io.swagger.v3.core.util.Yaml;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 public class JavaClientCodegen extends AbstractJavaCodegen implements BeanValidationFeatures, PerformBeanValidationFeatures, GzipFeatures {
     static final String MEDIA_TYPE = "mediaType";
 
-    @SuppressWarnings("hiding")
     private static final Logger LOGGER = LoggerFactory.getLogger(JavaClientCodegen.class);
 
     public static final String USE_RX_JAVA = "useRxJava";

--- a/src/test/java/io/swagger/codegen/languages/DefaultCodegenConfigTest.java
+++ b/src/test/java/io/swagger/codegen/languages/DefaultCodegenConfigTest.java
@@ -1,6 +1,7 @@
 package io.swagger.codegen.languages;
 
 import io.swagger.codegen.CodegenArgument;
+import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -14,8 +15,11 @@ public class DefaultCodegenConfigTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage, "");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "");
         Assert.assertEquals(codegen.apiPackage, "");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "");
         Assert.assertEquals(codegen.sortParamsByRequiredFlag, Boolean.TRUE);
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.TRUE);
     }
 
     @Test
@@ -27,8 +31,11 @@ public class DefaultCodegenConfigTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage, "xxx.yyyyy.zzzzzzz.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xxx.yyyyy.zzzzzzz.model");
         Assert.assertEquals(codegen.apiPackage, "xxx.yyyyy.zzzzzzz.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xxx.yyyyy.zzzzzzz.api");
         Assert.assertEquals(codegen.sortParamsByRequiredFlag, Boolean.FALSE);
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.FALSE);
     }
 
     private static class P_DefaultCodegenConfig extends DefaultCodegenConfig{

--- a/src/test/java/io/swagger/codegen/languages/DefaultCodegenConfigTest.java
+++ b/src/test/java/io/swagger/codegen/languages/DefaultCodegenConfigTest.java
@@ -15,9 +15,9 @@ public class DefaultCodegenConfigTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage, "");
-        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), null);
         Assert.assertEquals(codegen.apiPackage, "");
-        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), null);
         Assert.assertEquals(codegen.sortParamsByRequiredFlag, Boolean.TRUE);
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.TRUE);
         Assert.assertEquals(codegen.hideGenerationTimestamp, Boolean.TRUE);

--- a/src/test/java/io/swagger/codegen/languages/DefaultCodegenConfigTest.java
+++ b/src/test/java/io/swagger/codegen/languages/DefaultCodegenConfigTest.java
@@ -1,0 +1,60 @@
+package io.swagger.codegen.languages;
+
+import io.swagger.codegen.CodegenArgument;
+import io.swagger.codegen.CodegenType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.util.List;
+
+public class DefaultCodegenConfigTest {
+
+    @Test
+    public void testInitialValues() throws Exception {
+        final DefaultCodegenConfig codegen = new P_DefaultCodegenConfig();
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage, "");
+        Assert.assertEquals(codegen.apiPackage, "");
+        Assert.assertEquals(codegen.sortParamsByRequiredFlag, Boolean.TRUE);
+    }
+
+    @Test
+    public void testAdditionalProperties() throws Exception {
+        final DefaultCodegenConfig codegen = new P_DefaultCodegenConfig();
+        codegen.setModelPackage("xxx.yyyyy.zzzzzzz.model");
+        codegen.setApiPackage("xxx.yyyyy.zzzzzzz.api");
+        codegen.setSortParamsByRequiredFlag(false);
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage, "xxx.yyyyy.zzzzzzz.model");
+        Assert.assertEquals(codegen.apiPackage, "xxx.yyyyy.zzzzzzz.api");
+        Assert.assertEquals(codegen.sortParamsByRequiredFlag, Boolean.FALSE);
+    }
+
+    private static class P_DefaultCodegenConfig extends DefaultCodegenConfig{
+        @Override
+        public String getArgumentsLocation() {
+            return null;
+        }
+
+        @Override
+        public CodegenType getTag() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getHelp() {
+            return null;
+        }
+
+        @Override
+        public List<CodegenArgument> readLanguageArguments() {
+            return null;
+        }
+    }
+}

--- a/src/test/java/io/swagger/codegen/languages/DefaultCodegenConfigTest.java
+++ b/src/test/java/io/swagger/codegen/languages/DefaultCodegenConfigTest.java
@@ -20,14 +20,17 @@ public class DefaultCodegenConfigTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "");
         Assert.assertEquals(codegen.sortParamsByRequiredFlag, Boolean.TRUE);
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.TRUE);
+        Assert.assertEquals(codegen.hideGenerationTimestamp, Boolean.TRUE);
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
     }
 
     @Test
-    public void testAdditionalProperties() throws Exception {
+    public void testSetters() throws Exception {
         final DefaultCodegenConfig codegen = new P_DefaultCodegenConfig();
         codegen.setModelPackage("xxx.yyyyy.zzzzzzz.model");
         codegen.setApiPackage("xxx.yyyyy.zzzzzzz.api");
         codegen.setSortParamsByRequiredFlag(false);
+        codegen.setHideGenerationTimestamp(false);
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage, "xxx.yyyyy.zzzzzzz.model");
@@ -36,6 +39,27 @@ public class DefaultCodegenConfigTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xxx.yyyyy.zzzzzzz.api");
         Assert.assertEquals(codegen.sortParamsByRequiredFlag, Boolean.FALSE);
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.FALSE);
+        Assert.assertEquals(codegen.hideGenerationTimestamp, Boolean.FALSE);
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
+    }
+
+    @Test
+    public void testPutAdditionalProperties() throws Exception {
+        final DefaultCodegenConfig codegen = new P_DefaultCodegenConfig();
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xx.yyyyy.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xx.yyyyy.api");
+        codegen.additionalProperties().put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, false);
+        codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, false);
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage, "xx.yyyyy.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xx.yyyyy.model");
+        Assert.assertEquals(codegen.apiPackage, "xx.yyyyy.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xx.yyyyy.api");
+        Assert.assertEquals(codegen.sortParamsByRequiredFlag, Boolean.FALSE);
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.FALSE);
+        Assert.assertEquals(codegen.hideGenerationTimestamp, Boolean.FALSE);
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
     }
 
     private static class P_DefaultCodegenConfig extends DefaultCodegenConfig{

--- a/src/test/java/io/swagger/codegen/languages/java/AbstractJavaCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/languages/java/AbstractJavaCodegenTest.java
@@ -111,8 +111,11 @@ public class AbstractJavaCodegenTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage(), "invalidPackageName");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "invalidPackageName");
         Assert.assertEquals(codegen.apiPackage(), "invalidPackageName");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "invalidPackageName");
         Assert.assertEquals(codegen.invokerPackage, "io.swagger");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger");
     }
 
     @Test
@@ -125,10 +128,13 @@ public class AbstractJavaCodegenTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage(), "xxx.yyyyy.zzzzzzz.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xxx.yyyyy.zzzzzzz.model");
         Assert.assertEquals(codegen.apiPackage(), "xxx.yyyyy.zzzzzzz.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xxx.yyyyy.zzzzzzz.api");
         Assert.assertEquals(codegen.invokerPackage, "xxx.yyyyy.zzzzzzz.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.zzzzzzz.invoker");
         Assert.assertEquals(codegen.getSortParamsByRequiredFlag(), Boolean.FALSE);
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.FALSE);
     }
 
     @Test
@@ -147,6 +153,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.invokerPackage, "xxx.yyyyy.invoker.xxxxxx");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.invoker.xxxxxx");
         Assert.assertEquals(codegen.getSortParamsByRequiredFlag(), Boolean.TRUE);
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.TRUE);
     }
 
     public static class P_AbstractJavaCodegen extends AbstractJavaCodegen {

--- a/src/test/java/io/swagger/codegen/languages/java/AbstractJavaCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/languages/java/AbstractJavaCodegenTest.java
@@ -111,9 +111,9 @@ public class AbstractJavaCodegenTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage(), "invalidPackageName");
-        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "invalidPackageName");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), null);
         Assert.assertEquals(codegen.apiPackage(), "invalidPackageName");
-        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "invalidPackageName");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), null);
         Assert.assertEquals(codegen.invokerPackage, "io.swagger");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger");
     }

--- a/src/test/java/io/swagger/codegen/languages/java/AbstractJavaCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/languages/java/AbstractJavaCodegenTest.java
@@ -1,6 +1,7 @@
 package io.swagger.codegen.languages.java;
 
 import io.swagger.codegen.CodegenArgument;
+import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenType;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -13,32 +14,7 @@ import java.util.List;
 
 public class AbstractJavaCodegenTest {
 
-    private final AbstractJavaCodegen fakeJavaCodegen = new AbstractJavaCodegen() {
-        @Override
-        public String getArgumentsLocation() {
-            return null;
-        }
-
-        @Override
-        public CodegenType getTag() {
-            return null;
-        }
-
-        @Override
-        public String getName() {
-            return null;
-        }
-
-        @Override
-        public String getHelp() {
-            return null;
-        }
-
-        @Override
-        public List<CodegenArgument> readLanguageArguments() {
-            return null;
-        }
-    };
+    private final AbstractJavaCodegen fakeJavaCodegen = new P_AbstractJavaCodegen();
 
     @Test
     public void toEnumVarNameShouldNotShortenUnderScore() throws Exception {
@@ -127,5 +103,76 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(fakeJavaCodegen.toModelName("$name"), "Name");
         Assert.assertEquals(fakeJavaCodegen.toModelName("nam#e"), "Name");
         Assert.assertEquals(fakeJavaCodegen.toModelName("$another-fake?"), "AnotherFake");
+    }
+
+    @Test
+    public void testInitialPackageNamesValues() throws Exception {
+        final AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "invalidPackageName");
+        Assert.assertEquals(codegen.apiPackage(), "invalidPackageName");
+        Assert.assertEquals(codegen.invokerPackage, "io.swagger");
+    }
+
+    @Test
+    public void testPackageNamesSetWithSetters() throws Exception {
+        final AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
+        codegen.setModelPackage("xxx.yyyyy.zzzzzzz.model");
+        codegen.setApiPackage("xxx.yyyyy.zzzzzzz.api");
+        codegen.setInvokerPackage("xxx.yyyyy.zzzzzzz.invoker");
+        codegen.setSortParamsByRequiredFlag(false);
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xxx.yyyyy.zzzzzzz.model");
+        Assert.assertEquals(codegen.apiPackage(), "xxx.yyyyy.zzzzzzz.api");
+        Assert.assertEquals(codegen.invokerPackage, "xxx.yyyyy.zzzzzzz.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.zzzzzzz.invoker");
+        Assert.assertEquals(codegen.getSortParamsByRequiredFlag(), Boolean.FALSE);
+    }
+
+    @Test
+    public void testPackageNamesSetWithAdditionalProperties() throws Exception {
+        final AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xxx.yyyyy.model.xxxxxx");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xxx.yyyyy.api.xxxxxx");
+        codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE, "xxx.yyyyy.invoker.xxxxxx");
+        codegen.setSortParamsByRequiredFlag(true);
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xxx.yyyyy.model.xxxxxx");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xxx.yyyyy.model.xxxxxx");
+        Assert.assertEquals(codegen.apiPackage(), "xxx.yyyyy.api.xxxxxx");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xxx.yyyyy.api.xxxxxx");
+        Assert.assertEquals(codegen.invokerPackage, "xxx.yyyyy.invoker.xxxxxx");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.invoker.xxxxxx");
+        Assert.assertEquals(codegen.getSortParamsByRequiredFlag(), Boolean.TRUE);
+    }
+
+    public static class P_AbstractJavaCodegen extends AbstractJavaCodegen {
+        @Override
+        public String getArgumentsLocation() {
+            return null;
+        }
+
+        @Override
+        public CodegenType getTag() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getHelp() {
+            return null;
+        }
+
+        @Override
+        public List<CodegenArgument> readLanguageArguments() {
+            return null;
+        }
     }
 }

--- a/src/test/java/io/swagger/codegen/languages/java/AbstractJavaJAXRSServerCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/languages/java/AbstractJavaJAXRSServerCodegenTest.java
@@ -26,7 +26,9 @@ public class AbstractJavaJAXRSServerCodegenTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage(), "io.swagger.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "io.swagger.model");
         Assert.assertEquals(codegen.apiPackage(), "io.swagger.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "io.swagger.api");
         Assert.assertEquals(codegen.invokerPackage, "io.swagger.api");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger.api");
     }
@@ -40,7 +42,9 @@ public class AbstractJavaJAXRSServerCodegenTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage(), "xx.yyyyyyyy.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xx.yyyyyyyy.model");
         Assert.assertEquals(codegen.apiPackage(), "xx.yyyyyyyy.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xx.yyyyyyyy.api");
         Assert.assertEquals(codegen.invokerPackage, "xx.yyyyyyyy.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xx.yyyyyyyy.invoker");
     }

--- a/src/test/java/io/swagger/codegen/languages/java/AbstractJavaJAXRSServerCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/languages/java/AbstractJavaJAXRSServerCodegenTest.java
@@ -1,6 +1,7 @@
 package io.swagger.codegen.languages.java;
 
 import io.swagger.codegen.CodegenArgument;
+import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -8,7 +9,59 @@ import java.util.List;
 
 public class AbstractJavaJAXRSServerCodegenTest {
 
-    private final AbstractJavaJAXRSServerCodegen fakeJavaJAXRSCodegen = new AbstractJavaJAXRSServerCodegen() {
+    private final AbstractJavaJAXRSServerCodegen fakeJavaJAXRSCodegen = new P_AbstractJavaJAXRSServerCodegen();
+
+    @Test
+    public void convertApiName() throws Exception {
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("name"), "NameApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("$name"), "NameApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("nam#e"), "NameApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("$another-fake?"), "AnotherFakeApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("fake_classname_tags 123#$%^"), "FakeClassnameTags123Api");
+    }
+
+    @Test
+    public void testInitialPackageNamesValues() throws Exception {
+        final AbstractJavaJAXRSServerCodegen codegen = new P_AbstractJavaJAXRSServerCodegen();
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "io.swagger.model");
+        Assert.assertEquals(codegen.apiPackage(), "io.swagger.api");
+        Assert.assertEquals(codegen.invokerPackage, "io.swagger.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger.api");
+    }
+
+    @Test
+    public void testPackageNamesSetWithSetters() throws Exception {
+        final AbstractJavaJAXRSServerCodegen codegen = new P_AbstractJavaJAXRSServerCodegen();
+        codegen.setModelPackage("xx.yyyyyyyy.model");
+        codegen.setApiPackage("xx.yyyyyyyy.api");
+        codegen.setInvokerPackage("xx.yyyyyyyy.invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xx.yyyyyyyy.model");
+        Assert.assertEquals(codegen.apiPackage(), "xx.yyyyyyyy.api");
+        Assert.assertEquals(codegen.invokerPackage, "xx.yyyyyyyy.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xx.yyyyyyyy.invoker");
+    }
+
+    @Test
+    public void testPackageNamesSetWithAdditionalProperties() throws Exception {
+        final AbstractJavaJAXRSServerCodegen codegen = new P_AbstractJavaJAXRSServerCodegen();
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xxx.yyyyy.mmmmm.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xxx.yyyyy.aaaaa.api");
+        codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE,"xxx.yyyyy.iiii.invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xxx.yyyyy.mmmmm.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xxx.yyyyy.mmmmm.model");
+        Assert.assertEquals(codegen.apiPackage(), "xxx.yyyyy.aaaaa.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xxx.yyyyy.aaaaa.api");
+        Assert.assertEquals(codegen.invokerPackage, "xxx.yyyyy.iiii.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.iiii.invoker");
+    }
+
+    private static class P_AbstractJavaJAXRSServerCodegen extends AbstractJavaJAXRSServerCodegen {
         @Override
         public String getArgumentsLocation() {
             return null;
@@ -33,14 +86,5 @@ public class AbstractJavaJAXRSServerCodegenTest {
         public List<CodegenArgument> readLanguageArguments() {
             return null;
         }
-    };
-
-    @Test
-    public void convertApiName() throws Exception {
-        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("name"), "NameApi");
-        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("$name"), "NameApi");
-        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("nam#e"), "NameApi");
-        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("$another-fake?"), "AnotherFakeApi");
-        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("fake_classname_tags 123#$%^"), "FakeClassnameTags123Api");
     }
 }

--- a/src/test/java/io/swagger/codegen/languages/java/JavaClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/languages/java/JavaClientCodegenTest.java
@@ -1,5 +1,6 @@
 package io.swagger.codegen.languages.java;
 
+import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenModelFactory;
 import io.swagger.codegen.CodegenModelType;
@@ -172,5 +173,74 @@ public class JavaClientCodegenTest {
         CodegenModel result = codegen.fromModel("CompSche",
                 new ComposedSchema());
         Assert.assertEquals(result.name, "CompSche");
+    }
+
+    @Test
+    public void testInitialPackageNamesValues() throws Exception {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "io.swagger.client.model");
+        Assert.assertEquals(codegen.apiPackage(), "io.swagger.client.api");
+        Assert.assertEquals(codegen.invokerPackage, "io.swagger.client");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger.client");
+    }
+
+    @Test
+    public void testPackageNamesSetWithSetters() throws Exception {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setModelPackage("xxx.yyyyy.zzzzzzz.model");
+        codegen.setApiPackage("xxx.yyyyy.zzzzzzz.api");
+        codegen.setInvokerPackage("xxx.yyyyy.zzzzzzz.invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xxx.yyyyy.zzzzzzz.model");
+        Assert.assertEquals(codegen.apiPackage(), "xxx.yyyyy.zzzzzzz.api");
+        Assert.assertEquals(codegen.invokerPackage, "xxx.yyyyy.zzzzzzz.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.zzzzzzz.invoker");
+    }
+
+    @Test
+    public void testPackageNamesSetWithAdditionalProperties() throws Exception {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xxx.yyyyy.zzzzzzz.mmmmm.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xxx.yyyyy.zzzzzzz.aaaaa.api");
+        codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE,"xxx.yyyyy.zzzzzzz.iiii.invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xxx.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xxx.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.apiPackage(), "xxx.yyyyy.zzzzzzz.aaaaa.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xxx.yyyyy.zzzzzzz.aaaaa.api");
+        Assert.assertEquals(codegen.invokerPackage, "xxx.yyyyy.zzzzzzz.iiii.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.zzzzzzz.iiii.invoker");
+    }
+
+    @Test
+    public void testPackageNamesSetInvokerDerivedFromApi() throws Exception {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xxx.yyyyy.zzzzzzz.mmmmm.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xxx.yyyyy.zzzzzzz.aaaaa.api");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xxx.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xxx.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.apiPackage(), "xxx.yyyyy.zzzzzzz.aaaaa.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xxx.yyyyy.zzzzzzz.aaaaa.api");
+        Assert.assertEquals(codegen.invokerPackage, "xxx.yyyyy.zzzzzzz.aaaaa");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.zzzzzzz.aaaaa");
+    }
+
+    @Test
+    public void testPackageNamesSetInvokerDerivedFromModel() throws Exception {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xxx.yyyyy.zzzzzzz.mmmmm.model");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xxx.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xxx.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.apiPackage(), "io.swagger.client.api");
+        Assert.assertEquals(codegen.invokerPackage, "xxx.yyyyy.zzzzzzz.mmmmm");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.zzzzzzz.mmmmm");
     }
 }

--- a/src/test/java/io/swagger/codegen/languages/java/JavaClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/languages/java/JavaClientCodegenTest.java
@@ -181,7 +181,9 @@ public class JavaClientCodegenTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage(), "io.swagger.client.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "io.swagger.client.model");
         Assert.assertEquals(codegen.apiPackage(), "io.swagger.client.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "io.swagger.client.api");
         Assert.assertEquals(codegen.invokerPackage, "io.swagger.client");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger.client");
     }
@@ -195,7 +197,9 @@ public class JavaClientCodegenTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage(), "xxx.yyyyy.zzzzzzz.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xxx.yyyyy.zzzzzzz.model");
         Assert.assertEquals(codegen.apiPackage(), "xxx.yyyyy.zzzzzzz.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xxx.yyyyy.zzzzzzz.api");
         Assert.assertEquals(codegen.invokerPackage, "xxx.yyyyy.zzzzzzz.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.zzzzzzz.invoker");
     }
@@ -240,6 +244,7 @@ public class JavaClientCodegenTest {
         Assert.assertEquals(codegen.modelPackage(), "xxx.yyyyy.zzzzzzz.mmmmm.model");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xxx.yyyyy.zzzzzzz.mmmmm.model");
         Assert.assertEquals(codegen.apiPackage(), "io.swagger.client.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "io.swagger.client.api");
         Assert.assertEquals(codegen.invokerPackage, "xxx.yyyyy.zzzzzzz.mmmmm");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.zzzzzzz.mmmmm");
     }


### PR DESCRIPTION
Existing templates (here or in the `swagger-codegen` repository) are using these values:

```
{{modelPackage}}
{{apiPackage}}
{{invokerPackage}}
{{#sortParamsByRequiredFlag}}..{{/sortParamsByRequiredFlag}}
{{#hideGenerationTimestamp}}..{{/hideGenerationTimestamp}}
```

They need to be available in the `additionalProperties` map in order to be consumed from the `mustache` templates.

In addition, setting the value should be possible using setters. This is usefull when the generators are used directly (no maven plugin or no cli integration). Setter for `hideGenerationTimestamp` has been added.

`invokerPackage` is present only in `AbstractJavaCodegen`. Its value is derived from `apiPackage` or `modelPackage`. Current behavior needs to be preserved this is why some regression tests were implemented first in 7ad6ca24373e71f421aa96a5e82031cf33fb7d22.