### PR TITLE
Migrate "jaxrs-cxf-client"

### DIFF
--- a/src/main/java/io/swagger/codegen/languages/java/AbstractJavaJAXRSServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/AbstractJavaJAXRSServerCodegen.java
@@ -126,6 +126,10 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
 
     @Override
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
+        return jaxrsPostProcessOperations(objs);
+    }
+
+    static Map<String, Object> jaxrsPostProcessOperations(Map<String, Object> objs) {
         @SuppressWarnings("unchecked")
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         if ( operations != null ) {

--- a/src/main/java/io/swagger/codegen/languages/java/JavaCXFClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/JavaCXFClientCodegen.java
@@ -130,25 +130,9 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen implements BeanVal
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
         objs = super.postProcessOperations(objs);
-
-        Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
-        if (operations != null) {
-            List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
-            for (CodegenOperation operation : ops) {
-
-                if (operation.returnType == null) {
-                    operation.returnType = "void";
-                    // set vendorExtensions.x-java-is-response-void to true as
-                    // returnType is set to "void"
-                    operation.vendorExtensions.put("x-java-is-response-void", true);
-                }
-            }
-        }
-
-        return operations;
+        return AbstractJavaJAXRSServerCodegen.jaxrsPostProcessOperations(objs);
     }
 
     @Override

--- a/src/main/java/io/swagger/codegen/languages/java/JavaCXFClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/JavaCXFClientCodegen.java
@@ -1,0 +1,180 @@
+package io.swagger.codegen.languages.java;
+
+import io.swagger.codegen.CliOption;
+import io.swagger.codegen.CodegenModel;
+import io.swagger.codegen.CodegenOperation;
+import io.swagger.codegen.CodegenProperty;
+import io.swagger.codegen.CodegenType;
+import io.swagger.codegen.SupportingFile;
+import io.swagger.codegen.languages.features.BeanValidationFeatures;
+import io.swagger.codegen.languages.features.GzipTestFeatures;
+import io.swagger.codegen.languages.features.LoggingTestFeatures;
+import io.swagger.codegen.languages.features.UseGenericResponseFeatures;
+import io.swagger.v3.oas.models.Operation;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class JavaCXFClientCodegen extends AbstractJavaCodegen implements BeanValidationFeatures, UseGenericResponseFeatures, GzipTestFeatures, LoggingTestFeatures {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JavaCXFClientCodegen.class);
+
+    /**
+     * Name of the sub-directory in "src/main/resource" where to find the
+     * Mustache template for the JAX-RS Codegen.
+     */
+    protected static final String JAXRS_TEMPLATE_DIRECTORY_NAME = "JavaJaxRS";
+
+    protected boolean useBeanValidation = false;
+
+    protected boolean useGenericResponse = false;
+
+    protected boolean useGzipFeatureForTests = false;
+
+    protected boolean useLoggingFeatureForTests = false;
+
+    public JavaCXFClientCodegen() {
+        super();
+
+        supportsInheritance = true;
+
+        sourceFolder = "src/gen/java";
+        invokerPackage = "io.swagger.api";
+        artifactId = "swagger-jaxrs-client";
+        dateLibrary = "legacy"; // TODO: add joda support to all jax-rs
+
+        apiPackage = "io.swagger.api";
+        modelPackage = "io.swagger.model";
+
+        outputFolder = "generated-code/JavaJaxRS-CXF";
+
+        typeMapping.put("date", "LocalDate");
+
+        importMapping.put("LocalDate", "org.joda.time.LocalDate");
+
+        cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations"));
+
+        cliOptions.add(CliOption.newBoolean(USE_GZIP_FEATURE_FOR_TESTS, "Use Gzip Feature for tests"));
+        cliOptions.add(CliOption.newBoolean(USE_LOGGING_FEATURE_FOR_TESTS, "Use Logging Feature for tests"));
+
+        cliOptions.add(CliOption.newBoolean(USE_GENERIC_RESPONSE, "Use generic response"));
+    }
+
+    @Override
+    public void processOpts() {
+        super.processOpts();
+
+        if (StringUtils.isNotBlank(templateVersion)) {
+            embeddedTemplateDir = templateDir = String.format("%s/" + JAXRS_TEMPLATE_DIRECTORY_NAME + "/cxf", templateVersion);
+        }
+        else {
+            embeddedTemplateDir = templateDir = String.format("%s/" + JAXRS_TEMPLATE_DIRECTORY_NAME + "/cxf", DEFAULT_TEMPLATE_VERSION);
+        }
+
+        // clear model and api doc template as this codegen
+        // does not support auto-generated markdown doc at the moment
+        // TODO: add doc templates
+        modelDocTemplateFiles.remove("model_doc.mustache");
+        apiDocTemplateFiles.remove("api_doc.mustache");
+
+        if (additionalProperties.containsKey(USE_BEANVALIDATION)) {
+            boolean useBeanValidationProp = convertPropertyToBooleanAndWriteBack(USE_BEANVALIDATION);
+            this.setUseBeanValidation(useBeanValidationProp);
+        }
+
+        if (additionalProperties.containsKey(USE_GENERIC_RESPONSE)) {
+            this.setUseGenericResponse(convertPropertyToBoolean(USE_GENERIC_RESPONSE));
+        }
+
+        if (useGenericResponse) {
+            writePropertyBack(USE_GENERIC_RESPONSE, useGenericResponse);
+        }
+
+        this.setUseGzipFeatureForTests(convertPropertyToBooleanAndWriteBack(USE_GZIP_FEATURE_FOR_TESTS));
+        this.setUseLoggingFeatureForTests(convertPropertyToBooleanAndWriteBack(USE_LOGGING_FEATURE_FOR_TESTS));
+
+        supportingFiles.clear(); // Don't need extra files provided by
+                                 // AbstractJAX-RS & Java Codegen
+
+        writeOptional(outputFolder, new SupportingFile("pom.mustache", "", "pom.xml"));
+
+    }
+
+    @Override
+    public String getName() {
+        return "jaxrs-cxf-client";
+    }
+
+    @Override
+    public CodegenType getTag() {
+        return CodegenType.CLIENT;
+    }
+
+    @Override
+    public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
+        super.addOperationToGroup(tag, resourcePath, operation, co, operations);
+        co.subresourceOperation = !co.path.isEmpty();
+    }
+
+    @Override
+    public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
+        super.postProcessModelProperty(model, property);
+        model.imports.remove("ApiModelProperty");
+        model.imports.remove("ApiModel");
+        model.imports.remove("JsonSerialize");
+        model.imports.remove("ToStringSerializer");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
+        objs = super.postProcessOperations(objs);
+
+        Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
+        if (operations != null) {
+            List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
+            for (CodegenOperation operation : ops) {
+
+                if (operation.returnType == null) {
+                    operation.returnType = "void";
+                    // set vendorExtensions.x-java-is-response-void to true as
+                    // returnType is set to "void"
+                    operation.vendorExtensions.put("x-java-is-response-void", true);
+                }
+            }
+        }
+
+        return operations;
+    }
+
+    @Override
+    public String getHelp() {
+        return "[WORK IN PROGRESS: generated code depends from Swagger v2 libraries] "
+                + "Generates a Java JAXRS Client based on Apache CXF framework.";
+    }
+
+    public void setUseBeanValidation(boolean useBeanValidation) {
+        this.useBeanValidation = useBeanValidation;
+    }
+
+    public void setUseGzipFeatureForTests(boolean useGzipFeatureForTests) {
+        this.useGzipFeatureForTests = useGzipFeatureForTests;
+    }
+
+    public void setUseLoggingFeatureForTests(boolean useLoggingFeatureForTests) {
+        this.useLoggingFeatureForTests = useLoggingFeatureForTests;
+    }
+
+    public void setUseGenericResponse(boolean useGenericResponse) {
+        this.useGenericResponse = useGenericResponse;
+    }
+
+    @Override
+    public String getArgumentsLocation() {
+        return "";
+    }
+}

--- a/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
+++ b/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
@@ -2,6 +2,7 @@ io.swagger.codegen.languages.html.StaticDocCodegen
 io.swagger.codegen.languages.html.StaticHtmlCodegen
 io.swagger.codegen.languages.html.StaticHtml2Codegen
 io.swagger.codegen.languages.java.JavaClientCodegen
+io.swagger.codegen.languages.java.JavaCXFClientCodegen
 io.swagger.codegen.languages.java.JavaCXFServerCodegen
 io.swagger.codegen.languages.java.JavaInflectorServerCodegen
 io.swagger.codegen.languages.java.JavaJAXRSCXFCDIServerCodegen

--- a/src/test/java/io/swagger/codegen/languages/java/JavaCXFClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/languages/java/JavaCXFClientCodegenTest.java
@@ -1,0 +1,59 @@
+package io.swagger.codegen.languages.java;
+
+import io.swagger.codegen.CodegenOperation;
+import io.swagger.codegen.CodegenResponse;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JavaCXFClientCodegenTest {
+
+    @Test
+    public void responseWithoutContent() throws Exception {
+        final Schema listOfPets = new ArraySchema()
+                .items(new Schema<>().$ref("#/components/schemas/Pet"));
+        Operation operation = new Operation().responses(new ApiResponses()
+                .addApiResponse("200", new ApiResponse()
+                        .description("Return a list of pets")
+                        .content(new Content().addMediaType("application/json", 
+                                new MediaType().schema(listOfPets))))
+                .addApiResponse("400", new ApiResponse()
+                        .description("Error")));
+        final Map<String, Schema> allDefinitions = Collections.singletonMap("Pet", new ObjectSchema());
+
+        final JavaCXFClientCodegen codegen = new JavaCXFClientCodegen();
+        final CodegenOperation co = codegen.fromOperation("getAllPets", "GET", operation, allDefinitions);
+
+        Map<String, Object> objs = new HashMap<>();
+        objs.put("operations", Collections.singletonMap("operation", Collections.singletonList(co)));
+        objs.put("imports", Collections.emptyList());
+        codegen.postProcessOperations(objs);
+
+        Assert.assertEquals(co.responses.size(), 2);
+        CodegenResponse cr1 = co.responses.get(0);
+        Assert.assertEquals(cr1.code, "200");
+        Assert.assertEquals(cr1.baseType, "Pet");
+        Assert.assertEquals(cr1.dataType, "List<Pet>");
+        Assert.assertFalse(cr1.vendorExtensions.containsKey("x-java-is-response-void"));
+
+        CodegenResponse cr2 = co.responses.get(1);
+        Assert.assertEquals(cr2.code, "400");
+        Assert.assertEquals(cr2.baseType, "Void");
+        Assert.assertEquals(cr2.dataType, "void");
+        Assert.assertEquals(cr2.vendorExtensions.get("x-java-is-response-void"), Boolean.TRUE);
+    }
+
+
+}


### PR DESCRIPTION
Migration of `jaxrs-cxf-client` containing the fix for https://github.com/swagger-api/swagger-codegen/issues/7853

Mirgration Guide in the wiki: [Swagger Codegen migration (swagger codegen generators repository)](https://github.com/swagger-api/swagger-codegen/wiki/Swagger-Codegen-migration-(swagger-codegen-generators-repository))

Known issues:

* Generated code depends from Swagger v2 libraries (as indicated in the help message)
* Blank spaces in the generated code (handlebars is used instead of mustache, fine-tuning of the templates is requested)