### PR TITLE
Added jaxrs-di codegen

### DIFF
--- a/src/main/java/io/swagger/codegen/languages/java/JavaJerseyDIServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/JavaJerseyDIServerCodegen.java
@@ -1,0 +1,38 @@
+package io.swagger.codegen.languages.java;
+
+/**
+ * Generates a Java JAXRS API using jersey.
+ * Delegates to a service interface.
+ */
+public class JavaJerseyDIServerCodegen extends JavaJerseyServerCodegen {
+
+    public JavaJerseyDIServerCodegen() {
+        super();
+        outputFolder = "generated-code/JavaJaxRS-DI";
+    }
+
+    @Override
+    public String getName() {
+        return "jaxrs-di";
+    }
+
+    @Override
+    public String getHelp() {
+        return "[WORK IN PROGRESS: generated code depends from Swagger v2 libraries] "
+                + "Generates a Java JAXRS API delegating to a service interface.";
+    }
+
+    @Override
+    public void addTemplateFiles() {
+        super.apiTemplateFiles.remove("api.mustache");
+        super.apiTemplateFiles.put("di/api.mustache", ".java");
+        super.apiTemplateFiles.put("di/apiService.mustache", ".java");
+
+        apiTestTemplateFiles.clear(); // TODO: add test template
+        // clear model and api doc template as this codegen
+        // does not support auto-generated markdown doc at the moment
+        // TODO: add doc templates
+        modelDocTemplateFiles.remove("model_doc.mustache");
+        apiDocTemplateFiles.remove("api_doc.mustache");
+    }
+}

--- a/src/main/java/io/swagger/codegen/languages/java/JavaJerseyServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/JavaJerseyServerCodegen.java
@@ -88,16 +88,7 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
             }
         }
 
-        apiTemplateFiles.put("apiService.mustache", ".java");
-        apiTemplateFiles.put("apiServiceImpl.mustache", ".java");
-        apiTemplateFiles.put("apiServiceFactory.mustache", ".java");
-        apiTestTemplateFiles.clear(); // TODO: add test template
-
-        // clear model and api doc template as this codegen
-        // does not support auto-generated markdown doc at the moment
-        // TODO: add doc templates
-        modelDocTemplateFiles.remove("model_doc.mustache");
-        apiDocTemplateFiles.remove("api_doc.mustache");
+        addTemplateFiles();
 
         // use default library if unset
         if (StringUtils.isEmpty(library)) {
@@ -112,6 +103,11 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
             this.setUseTags(Boolean.valueOf(additionalProperties.get(USE_TAGS).toString()));
         }
 
+        addDateLibrary();
+        addSupportingFiles();
+    }
+
+    public void addDateLibrary() {
         if ("joda".equals(dateLibrary)) {
             supportingFiles.add(new SupportingFile("JodaDateTimeProvider.mustache", (sourceFolder + '/' + apiPackage).replace(".", "/"), "JodaDateTimeProvider.java"));
             supportingFiles.add(new SupportingFile("JodaLocalDateProvider.mustache", (sourceFolder + '/' + apiPackage).replace(".", "/"), "JodaLocalDateProvider.java"));
@@ -120,7 +116,21 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
             supportingFiles.add(new SupportingFile("OffsetDateTimeProvider.mustache", (sourceFolder + '/' + apiPackage).replace(".", "/"), "OffsetDateTimeProvider.java"));
             supportingFiles.add(new SupportingFile("LocalDateProvider.mustache", (sourceFolder + '/' + apiPackage).replace(".", "/"), "LocalDateProvider.java"));
         }
+    }
 
+    public void addTemplateFiles() {
+        apiTemplateFiles.put("apiService.mustache", ".java");
+        apiTemplateFiles.put("apiServiceImpl.mustache", ".java");
+        apiTemplateFiles.put("apiServiceFactory.mustache", ".java");
+        apiTestTemplateFiles.clear(); // TODO: add test template
+        // clear model and api doc template as this codegen
+        // does not support auto-generated markdown doc at the moment
+        // TODO: add doc templates
+        modelDocTemplateFiles.remove("model_doc.mustache");
+        apiDocTemplateFiles.remove("api_doc.mustache");
+    }
+
+    public void addSupportingFiles() {
         writeOptional(outputFolder, new SupportingFile("pom.mustache", "", "pom.xml"));
         writeOptional(outputFolder, new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("ApiException.mustache", (sourceFolder + '/' + apiPackage).replace(".", "/"), "ApiException.java"));

--- a/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
+++ b/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
@@ -8,6 +8,7 @@ io.swagger.codegen.languages.java.JavaInflectorServerCodegen
 io.swagger.codegen.languages.java.JavaJAXRSCXFCDIServerCodegen
 io.swagger.codegen.languages.java.JavaJAXRSSpecServerCodegen
 io.swagger.codegen.languages.java.JavaJerseyServerCodegen
+io.swagger.codegen.languages.java.JavaJerseyDIServerCodegen
 io.swagger.codegen.languages.java.JavaResteasyEapServerCodegen
 io.swagger.codegen.languages.java.JavaResteasyServerCodegen
 io.swagger.codegen.languages.kotlin.KotlinClientCodegen

--- a/src/main/resources/v2/Java/libraries/feign/api.mustache
+++ b/src/main/resources/v2/Java/libraries/feign/api.mustache
@@ -37,8 +37,8 @@ public interface {{classname}} extends ApiClient.Api {
    */
   @RequestLine("{{httpMethod}} {{{path}}}{{#hasQueryParams}}?{{/hasQueryParams}}{{#queryParams}}{{baseName}}={{=<% %>=}}{<%paramName%>}<%={{ }}=%>{{#has this 'more'}}&{{/has}}{{/queryParams}}")
   @Headers({
-    "Content-Type: {{vendorExtensions.x-contentType}}",
-    "Accept: {{vendorExtensions.x-accepts}}",{{#headerParams}}
+  {{#vendorExtensions.x-contentType}}"Content-Type: {{vendorExtensions.x-contentType}}"{{#vendorExtensions.x-accepts}},{{/vendorExtensions.x-accepts}}{{/vendorExtensions.x-contentType}}
+  {{#vendorExtensions.x-accepts}}"Accept: {{vendorExtensions.x-accepts}}"{{/vendorExtensions.x-accepts}}{{#headerParams}},{{/headerParams}}{{#headerParams}}
     "{{baseName}}: {{=<% %>=}}{<%paramName%>}<%={{ }}=%>"{{#has this 'more'}},
     {{/has}}{{/headerParams}}
   })
@@ -75,8 +75,8 @@ public interface {{classname}} extends ApiClient.Api {
    */
   @RequestLine("{{httpMethod}} {{{path}}}?{{#queryParams}}{{baseName}}={{=<% %>=}}{<%paramName%>}<%={{ }}=%>{{#has this 'more'}}&{{/has}}{{/queryParams}}")
   @Headers({
-  "Content-Type: {{vendorExtensions.x-contentType}}",
-  "Accept: {{vendorExtensions.x-accepts}}",{{#headerParams}}
+  {{#vendorExtensions.x-contentType}}"Content-Type: {{vendorExtensions.x-contentType}}"{{#vendorExtensions.x-accepts}},{{/vendorExtensions.x-accepts}}{{/vendorExtensions.x-contentType}}
+  {{#vendorExtensions.x-accepts}}"Accept: {{vendorExtensions.x-accepts}}"{{/vendorExtensions.x-accepts}}{{#headerParams}},{{/headerParams}}{{#headerParams}}
       "{{baseName}}: {{=<% %>=}}{<%paramName%>}<%={{ }}=%>"{{#has this 'more'}},
       {{/has}}{{/headerParams}}
   })

--- a/src/main/resources/v2/JavaJaxRS/di/api.mustache
+++ b/src/main/resources/v2/JavaJaxRS/di/api.mustache
@@ -1,0 +1,66 @@
+package {{package}};
+
+import {{modelPackage}}.*;
+import {{package}}.{{classname}}Service;
+
+import io.swagger.annotations.ApiParam;
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+import java.util.Map;
+import java.util.List;
+
+import java.io.InputStream;
+
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataParam;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.*;
+{{#useBeanValidation}}
+import javax.validation.constraints.*;
+{{/useBeanValidation}}
+
+@Path("/{{{baseName}}}")
+{{#hasConsumes}}@Consumes({ {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} }){{/hasConsumes}}
+{{#hasProduces}}@Produces({ {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }){{/hasProduces}}
+@io.swagger.annotations.Api(description = "the {{{baseName}}} API")
+{{>generatedAnnotation}}
+{{#operations}}
+public class {{classname}}  {
+
+   private {{classname}}Service delegate;
+
+   protected {{classname}}() {
+   }
+
+   @javax.inject.Inject
+   public {{classname}}({{classname}}Service delegate) {
+      this.delegate = delegate;
+   }
+
+{{#operation}}
+    @{{httpMethod}}
+    {{#subresourceOperation}}@Path("{{{path}}}"){{/subresourceOperation}}
+    {{#has this 'consumes'}}@Consumes({ {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} }){{/has}}
+    {{#has this 'produces'}}@Produces({ {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }){{/has}}
+    @io.swagger.annotations.ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnBaseType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
+        {{#authMethods}}@io.swagger.annotations.Authorization(value = "{{name}}"{{#is this 'oauth'}}, scopes = {
+            {{#scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},
+            {{/hasMore}}{{/scopes}}
+        }{{/is}}){{#hasMore}},
+        {{/hasMore}}{{/authMethods}}
+    }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}",{{/vendorExtensions.x-tags}} })
+    @io.swagger.annotations.ApiResponses(value = { {{#responses}}
+        @io.swagger.annotations.ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{baseType}}}.class{{#containerType}}, responseContainer = "{{{containerType}}}"{{/containerType}}){{#has this 'more'}},
+        {{/has}}{{/responses}} })
+    public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}},{{/allParams}}@Context SecurityContext securityContext)
+    throws NotFoundException {
+        return delegate.{{nickname}}({{#allParams}}{{#is this 'file'}}{{paramName}}InputStream, {{paramName}}Detail{{/is}}{{#isNot this 'file'}}{{paramName}}{{/isNot}},{{/allParams}}securityContext);
+    }
+{{/operation}}
+}
+{{/operations}}

--- a/src/main/resources/v2/JavaJaxRS/di/apiService.mustache
+++ b/src/main/resources/v2/JavaJaxRS/di/apiService.mustache
@@ -1,0 +1,28 @@
+package {{package}};
+
+import {{package}}.*;
+import {{modelPackage}}.*;
+
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+import java.util.Map;
+import java.util.List;
+
+import java.io.InputStream;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+{{#useBeanValidation}}
+import javax.validation.constraints.*;
+{{/useBeanValidation}}
+{{>generatedAnnotation}}
+{{#operations}}
+public interface {{classname}}Service {
+    {{#operation}}
+    public Response {{nickname}}({{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{>serviceFormParams}},{{/allParams}}SecurityContext securityContext);
+    {{/operation}}
+}
+{{/operations}}


### PR DESCRIPTION
Implementations of generated API service interfaces are injected to the
API by the DI container. I am using it with spring boot.
Will likely work with any container supporting javax.inject.Inject.

API uses constructor injection. Added a protected no-args constructor
for CDI. At least weld needs it to be able to create proxies.