### PR TITLE
Add close tag to HTML anchors

### DIFF
--- a/src/main/resources/v2/htmlDocs/index.mustache
+++ b/src/main/resources/v2/htmlDocs/index.mustache
@@ -48,7 +48,7 @@
   {{#operations}}
   <h1><a name="{{baseName}}">{{baseName}}</a></h1>
   {{#operation}}
-  <div class="method"><a name="{{nickname}}"/>
+  <div class="method"><a name="{{nickname}}"></a>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="{{httpMethod}}"><code class="huge"><span class="http-method">{{httpMethod}}</span> {{path}}</code></pre></div>


### PR DESCRIPTION
According to HTML specs, <a> MUST HAVE a closing tag, so `<a name="foo" />` is invalid syntax. Fortunately, browsers switch to quirks mode when facing this issue, so there is appears to be working well, but the browsers won't behave as expected sometimes, for example if removing the link to top which follows this anchor two lines below. 

More information: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a