### PR TITLE
Retrofit: Query Params generates a Path annotation

### DIFF
--- a/src/main/resources/v2/Java/libraries/retrofit2/queryParams.mustache
+++ b/src/main/resources/v2/Java/libraries/retrofit2/queryParams.mustache
@@ -1,1 +1,1 @@
-{{#is this 'query-param'}}@retrofit2.http.Path("{{baseName}}") {{{dataType}}} {{paramName}}{{/is}}
+{{#is this 'query-param'}}@retrofit2.http.Query("{{baseName}}") {{{dataType}}} {{paramName}}{{/is}}


### PR DESCRIPTION
Before this commit, the generator create a @retrofit2.http.Path for a query parameter. This path replace the @retrofit2.http.Query by a @retrofit2.http.Path