### PR TITLE
[Spring] Add @JsonTypeId annotation to fields used as discriminator property

### DIFF
--- a/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/languages/java/AbstractJavaCodegen.java
@@ -372,6 +372,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         importMapping.put("JsonProperty", "com.fasterxml.jackson.annotation.JsonProperty");
         importMapping.put("JsonSubTypes", "com.fasterxml.jackson.annotation.JsonSubTypes");
         importMapping.put("JsonTypeInfo", "com.fasterxml.jackson.annotation.JsonTypeInfo");
+        importMapping.put("JsonTypeId", "com.fasterxml.jackson.annotation.JsonTypeId");
         importMapping.put("JsonCreator", "com.fasterxml.jackson.annotation.JsonCreator");
         importMapping.put("JsonValue", "com.fasterxml.jackson.annotation.JsonValue");
         importMapping.put("SerializedName", "com.google.gson.annotations.SerializedName");
@@ -895,6 +896,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
             // needed by all pojos, but not enums
             model.imports.add("ApiModelProperty");
             model.imports.add("ApiModel");
+        }
+
+        if (model.discriminator != null && model.discriminator.getPropertyName().equals(property.baseName)) {
+            property.vendorExtensions.put("x-is-discriminator-property", true);
+
+            model.imports.add("JsonTypeId");
         }
     }
 

--- a/src/main/resources/v2/JavaSpring/pojo.mustache
+++ b/src/main/resources/v2/JavaSpring/pojo.mustache
@@ -24,8 +24,9 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
       {{/items}}
     {{/is}}
   {{#if jackson}}
-  @JsonProperty("{{baseName}}"){{#withXml}}
-  @JacksonXmlProperty({{#is this 'xml-attribute'}}isAttribute = true, {{/is}}{{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}"){{/withXml}}
+  @JsonProperty("{{baseName}}")
+  {{#is this 'discriminator-property'}}@JsonTypeId{{/is}}
+  {{#withXml}}@JacksonXmlProperty({{#is this 'xml-attribute'}}isAttribute = true, {{/is}}{{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}"){{/withXml}}
   {{/if}}
   {{#gson}}
   @SerializedName("{{baseName}}")


### PR DESCRIPTION
Fixes #105

I attempted to follow the pattern already in use with using `vendorExtensions` and `#is` for additional features, while keeping as much logic as possible out of the handlebars template.

Please let me know if I took the incorrect approach here.