### PR TITLE
Issue 8330 - use consistent class name for parents so java class EXTENDS works properly

### DIFF
--- a/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/languages/DefaultCodegenConfig.java
@@ -1293,7 +1293,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
             }
             if (parent != null) {
                 codegenModel.parentSchema = parentName;
-                codegenModel.parent = StringUtils.capitalize(modelNamePrefix + parentName + modelNameSuffix);
+                codegenModel.parent = toModelName(parentName);
                 addImport(codegenModel, codegenModel.parent);
                 if (allDefinitions != null) {
                     if (supportsInheritance) {


### PR DESCRIPTION
Use toModelName to insure consistency in class names