### PR TITLE
Adds Discriminator support for Gson-OkHttp

### DIFF
--- a/src/main/resources/v2/Java/libraries/okhttp-gson/JSON.mustache
+++ b/src/main/resources/v2/Java/libraries/okhttp-gson/JSON.mustache
@@ -4,6 +4,9 @@ package {{invokerPackage}};
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import io.gsonfire.GsonFireBuilder;
+import io.gsonfire.TypeSelector;
 import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.internal.bind.util.ISO8601Utils;
@@ -22,6 +25,8 @@ import org.threeten.bp.OffsetDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 {{/threetenbp}}
 
+import {{modelPackage}}.*;
+
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.Type;
@@ -34,6 +39,8 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 {{/java8}}
 import java.util.Date;
+import java.util.Map;
+import java.util.HashMap;
 
 public class JSON {
     private Gson gson;
@@ -49,8 +56,51 @@ public class JSON {
     private LocalDateTypeAdapter localDateTypeAdapter = new LocalDateTypeAdapter();
     {{/jsr310}}
 
+    public static GsonBuilder createGson() {
+        GsonFireBuilder fireBuilder = new GsonFireBuilder()
+        {{#parent}}
+          .registerTypeSelector({{classname}}.class, new TypeSelector<{{classname}}>() {
+            @Override
+            public Class<? extends {{classname}}> getClassForElement(JsonElement readElement) {
+                Map<String, Class<? extends {{classname}}>> classByDiscriminatorValue = new HashMap<>();
+                {{#if discriminator.mapping}}
+                    {{#each discriminator.mapping}}
+                    classByDiscriminatorValue.put("{{@key}}".toUpperCase(), {{this}}.class);
+                    {{/each}}
+                {{else}}
+                    {{#children}}
+                    classByDiscriminatorValue.put("{{name}}".toUpperCase(), {{classname}}.class);
+                    {{/children}}
+                    classByDiscriminatorValue.put("{{classname}}".toUpperCase(), {{classname}}.class);
+                {{/if}}
+                return getClassByDiscriminator(
+                            classByDiscriminatorValue,
+                            getDiscriminatorValue(readElement, "{{discriminator.propertyName}}"));
+            }
+          })
+        {{/parent}}
+        ;
+        return fireBuilder.createGsonBuilder();
+    }
+
+    private static String getDiscriminatorValue(JsonElement readElement, String discriminatorField) {
+        JsonElement element = readElement.getAsJsonObject().get(discriminatorField);
+        if(null == element) {
+            throw new IllegalArgumentException("missing discriminator field: <" + discriminatorField + ">");
+        }
+        return element.getAsString();
+    }
+
+    private static <T> Class<? extends T> getClassByDiscriminator(Map<String, Class<? extends T>> classByDiscriminatorValue, String discriminatorValue) {
+        Class<? extends T> clazz = classByDiscriminatorValue.get(discriminatorValue.toUpperCase());
+        if(null == clazz) {
+            throw new IllegalArgumentException("cannot determine model class of name: <" + discriminatorValue + ">");
+        }
+        return clazz;
+    }
+
     public JSON() {
-        gson = new GsonBuilder()
+        gson = createGson()
             .registerTypeAdapter(Date.class, dateTypeAdapter)
             .registerTypeAdapter(java.sql.Date.class, sqlDateTypeAdapter)
             {{#joda}}

--- a/src/main/resources/v2/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/src/main/resources/v2/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -109,6 +109,7 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.7.5'
     compile 'com.squareup.okhttp:logging-interceptor:2.7.5'
     compile 'com.google.code.gson:gson:2.8.1'
+    compile 'io.gsonfire:gson-fire:1.8.3'
     {{#joda}}
     compile 'joda-time:joda-time:2.9.9'
     {{/joda}}

--- a/src/main/resources/v2/Java/libraries/okhttp-gson/build.sbt.mustache
+++ b/src/main/resources/v2/Java/libraries/okhttp-gson/build.sbt.mustache
@@ -18,6 +18,7 @@ lazy val root = (project in file(".")).
       "com.squareup.okhttp" % "okhttp" % "2.7.5",
       "com.squareup.okhttp" % "logging-interceptor" % "2.7.5",
       "com.google.code.gson" % "gson" % "2.8.1",
+      "io.gsonfire" % "gson-fire" % "1.8.3" % "compile",
       {{#joda}}
       "joda-time" % "joda-time" % "2.9.9" % "compile",
       {{/joda}}

--- a/src/main/resources/v2/Java/libraries/okhttp-gson/pom.mustache
+++ b/src/main/resources/v2/Java/libraries/okhttp-gson/pom.mustache
@@ -198,6 +198,11 @@
       <artifactId>gson</artifactId>
       <version>${gson-version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.gsonfire</groupId>
+      <artifactId>gson-fire</artifactId>
+      <version>${gson-fire-version}</version>
+    </dependency>
     {{#joda}}
     <dependency>
       <groupId>joda-time</groupId>
@@ -275,6 +280,7 @@
     {{/useOas2}}
     <okhttp-version>2.7.5</okhttp-version>
     <gson-version>2.8.1</gson-version>
+    <gson-fire-version>1.8.3</gson-fire-version>
     {{#supportJava6}}
     <commons_io_version>2.5</commons_io_version>
     <commons_lang3_version>3.6</commons_lang3_version>


### PR DESCRIPTION
References: #122

Adds support for `descriminator` to Gson/OkHttp Java client using [GsonFireBuilder ](/julman99/gson-fire)1.8.3
A copy/paste of [2.0 generator](/swagger-api/swagger-codegen/blob/master/modules/swagger-codegen/src/main/resources/Java/JSON.mustache) updated to support [v3 Discriminator](/swagger-api/swagger-core/blob/master/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Discriminator.java)
Also supports discriminator mapping:
```yaml
    ReplyType:
      description: Reply type
      type: string
      enum:
        - accept
        - reject

    Reply:
      type: object
      required:
        - type
      discriminator:
        propertyName: type
        mapping:
          accept: AcceptReply
          reject: RejectReply
      properties:
        type:
          $ref: '#/components/schemas/ReplyType'

    AcceptReply
      allOf:
        - $ref: '#/components/schemas/Reply'
        - type: object

    RejectReply:
      allOf:
        - $ref: '#/components/schemas/Reply'
```