### PR TITLE
FIXED: PHP code generator rewrite TEMPLATE_DIR option

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/php/PhpClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/php/PhpClientCodegen.java
@@ -63,7 +63,7 @@ public class PhpClientCodegen extends DefaultCodegenConfig {
         apiTemplateFiles.put("api.mustache", ".php");
         modelTestTemplateFiles.put("model_test.mustache", ".php");
         apiTestTemplateFiles.put("api_test.mustache", ".php");
-        embeddedTemplateDir = templateDir = "php";
+        embeddedTemplateDir = "php";
         apiPackage = invokerPackage + "\\" + apiDirName;
         modelPackage = invokerPackage + "\\" + modelDirName;
 
@@ -241,9 +241,12 @@ public class PhpClientCodegen extends DefaultCodegenConfig {
 
         String templateVersion = getTemplateVersion();
         if (StringUtils.isNotBlank(templateVersion)) {
-            embeddedTemplateDir = templateDir = String.format("%s/php", templateVersion);
+            embeddedTemplateDir = String.format("%s" + File.separator + "php", templateVersion);
         } else {
-            embeddedTemplateDir = templateDir = String.format("%s/php", DEFAULT_TEMPLATE_VERSION);
+            embeddedTemplateDir = String.format("%s" + File.separator + "php", DEFAULT_TEMPLATE_VERSION);
+        }
+        if (StringUtils.isBlank(templateDir)) {
+            templateDir = embeddedTemplateDir;
         }
 
         if (additionalProperties.containsKey(PACKAGE_PATH)) {

--- a/src/test/java/io/swagger/codegen/v3/generators/php/PhpClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/php/PhpClientCodegenTest.java
@@ -20,6 +20,8 @@ public class PhpClientCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.TRUE);
         Assert.assertEquals(codegen.getHideGenerationTimestamp(), Boolean.TRUE);
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assert.assertEquals(codegen.templateDir(), "v2/php");
+        Assert.assertEquals(codegen.embeddedTemplateDir(), "v2/php");
     }
 
     @Test
@@ -62,5 +64,28 @@ public class PhpClientCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.FALSE);
         Assert.assertEquals(codegen.getHideGenerationTimestamp(), Boolean.FALSE);
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
+    }
+
+
+    @Test
+    public void testPutTemplateDirProperty() throws Exception {
+        final PhpClientCodegen codegen = new PhpClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.TEMPLATE_DIR, "/absolute/path");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.templateDir(), "/absolute/path");
+        Assert.assertEquals(codegen.embeddedTemplateDir(), "v2/php");
+    }
+
+
+    @Test
+    public void testPutTemplateDirPropertyWithTemplateVersion() throws Exception {
+        final PhpClientCodegen codegen = new PhpClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.TEMPLATE_DIR, "/absolute/path");
+        codegen.additionalProperties().put(CodegenConstants.TEMPLATE_VERSION, "v3");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.templateDir(), "/absolute/path");
+        Assert.assertEquals(codegen.embeddedTemplateDir(), "v3/php");
     }
 }


### PR DESCRIPTION
PHP code generator always use embedded templates and we can't use our templates for client (with `--template-dir` option in `swagger-codegen generate`)