### PR TITLE
[JAXRS-CXF-CDI] Invalid argument on OAS 3.0 annotation @Parameter

### DIFF
--- a/src/main/resources/v2/JavaJaxRS/allowableValues.mustache
+++ b/src/main/resources/v2/JavaJaxRS/allowableValues.mustache
@@ -1,1 +1,6 @@
+{{#useOas2}}
 {{#allowableValues}}allowableValues="{{#values}}{{{.}}}{{^@last}}, {{/@last}}{{/values}}{{^values}}range=[{{#min}}{{.}}{{/min}}{{^min}}-infinity{{/min}}, {{#max}}{{.}}{{/max}}{{^max}}infinity{{/max}}]{{/values}}"{{/allowableValues}}
+{{/useOas2}}
+{{^useOas2}}
+{{#allowableValues}}schema=@Schema(allowableValues={ {{#values}}"{{{.}}}"{{^@last}}, {{/@last}}{{/values}}{{^values}}{{/values}} }{{#min}}, minimum="{{.}}"{{/min}}{{#max}}, maximum="{{.}}"{{/max}}){{/allowableValues}}
+{{/useOas2}}

--- a/src/main/resources/v2/JavaJaxRS/cxf-cdi/allowableValues.mustache
+++ b/src/main/resources/v2/JavaJaxRS/cxf-cdi/allowableValues.mustache
@@ -1,1 +1,6 @@
+{{#useOas2}}
 {{#allowableValues}}allowableValues="{{#values}}{{{.}}}{{^@last}}, {{/@last}}{{/values}}{{^values}}range=[{{#min}}{{.}}{{/min}}{{^min}}-infinity{{/min}}, {{#max}}{{.}}{{/max}}{{^max}}infinity{{/max}}]{{/values}}"{{/allowableValues}}
+{{/useOas2}}
+{{^useOas2}}
+{{#allowableValues}}schema=@Schema(allowableValues={ {{#values}}"{{{.}}}"{{^@last}}, {{/@last}}{{/values}}{{^values}}{{/values}} }{{#min}}, minimum="{{.}}"{{/min}}{{#max}}, maximum="{{.}}"{{/max}}){{/allowableValues}}
+{{/useOas2}}

--- a/src/main/resources/v2/JavaJaxRS/cxf/allowableValues.mustache
+++ b/src/main/resources/v2/JavaJaxRS/cxf/allowableValues.mustache
@@ -1,1 +1,6 @@
+{{#useOas2}}
 {{#allowableValues}}allowableValues="{{#values}}{{{.}}}{{^@last}}, {{/@last}}{{/values}}{{^values}}range=[{{#min}}{{.}}{{/min}}{{^min}}-infinity{{/min}}, {{#max}}{{.}}{{/max}}{{^max}}infinity{{/max}}]{{/values}}"{{/allowableValues}}
+{{/useOas2}}
+{{^useOas2}}
+{{#allowableValues}}schema=@Schema(allowableValues={ {{#values}}"{{{.}}}"{{^@last}}, {{/@last}}{{/values}}{{^values}}{{/values}} }{{#min}}, minimum="{{.}}"{{/min}}{{#max}}, maximum="{{.}}"{{/max}}){{/allowableValues}}
+{{/useOas2}}

--- a/src/main/resources/v2/JavaJaxRS/resteasy/allowableValues.mustache
+++ b/src/main/resources/v2/JavaJaxRS/resteasy/allowableValues.mustache
@@ -1,1 +1,6 @@
+{{#useOas2}}
 {{#allowableValues}}allowableValues="{{#values}}{{{.}}}{{^@last}}, {{/@last}}{{/values}}{{^values}}range=[{{#min}}{{.}}{{/min}}{{^min}}-infinity{{/min}}, {{#max}}{{.}}{{/max}}{{^max}}infinity{{/max}}]{{/values}}"{{/allowableValues}}
+{{/useOas2}}
+{{^useOas2}}
+{{#allowableValues}}schema=@Schema(allowableValues={ {{#values}}"{{{.}}}"{{^@last}}, {{/@last}}{{/values}}{{^values}}{{/values}} }{{#min}}, minimum="{{.}}"{{/min}}{{#max}}, maximum="{{.}}"{{/max}}){{/allowableValues}}
+{{/useOas2}}

--- a/src/main/resources/v2/JavaJaxRS/spec/allowableValues.mustache
+++ b/src/main/resources/v2/JavaJaxRS/spec/allowableValues.mustache
@@ -1,1 +1,6 @@
+{{#useOas2}}
 {{#allowableValues}}allowableValues="{{#values}}{{{.}}}{{^@last}}, {{/@last}}{{/values}}{{^values}}range=[{{#min}}{{.}}{{/min}}{{^min}}-infinity{{/min}}, {{#max}}{{.}}{{/max}}{{^max}}infinity{{/max}}]{{/values}}"{{/allowableValues}}
+{{/useOas2}}
+{{^useOas2}}
+{{#allowableValues}}schema=@Schema(allowableValues={ {{#values}}"{{{.}}}"{{^@last}}, {{/@last}}{{/values}}{{^values}}{{/values}} }{{#min}}, minimum="{{.}}"{{/min}}{{#max}}, maximum="{{.}}"{{/max}}){{/allowableValues}}
+{{/useOas2}}

--- a/src/main/resources/v2/JavaJaxRS/spec/queryParams.mustache
+++ b/src/main/resources/v2/JavaJaxRS/spec/queryParams.mustache
@@ -1,4 +1,4 @@
 {{#is this 'query-param'}}{{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}} @QueryParam("{{baseName}}"){{#defaultValue}} @DefaultValue("{{{defaultValue}}}"){{/defaultValue}} 
 {{#useOas2}}{{#description}} @ApiParam("{{description}}"){{/description}}  {{{dataType}}} {{paramName}}{{/useOas2}}
-{{^useOas2}}{{#description}} @Parameter(description = {{description}}"){{/description}}  {{{dataType}}} {{paramName}}{{/useOas2}}
+{{^useOas2}}{{#description}} @Parameter(description = "{{description}}"){{/description}}  {{{dataType}}} {{paramName}}{{/useOas2}}
 {{/is}}


### PR DESCRIPTION
Fixing https://github.com/swagger-api/swagger-codegen-generators/issues/132 by properly passing allowed values through schema.

Generated fragment:
```
        @Parameter(
            description = "status",
            schema = @Schema(allowableValues = {"AVALIABLE", "PENDING"})
          )
          @QueryParam("status")
          String status
```
Or
```
          @Min(1)
          @Max(100)
          @Parameter(
            description = "",
            schema =
                @Schema(
                  allowableValues = {},
                  minimum = "1",
                  maximum = "100"
                )
          )
          @QueryParam("page")
          Integer page
```