### PR TITLE
Scala generators - Modify scala model generation

### DIFF
--- a/src/main/resources/mustache/scala/model.mustache
+++ b/src/main/resources/mustache/scala/model.mustache
@@ -7,11 +7,19 @@ import {{import}}
 
 {{#models}}
 {{#model}}
+/**
+{{#title}} * = {{{title}}} =
+ *
+{{/title}}
+{{#description}} * {{{description}}}
+ *
+{{/description}}
+{{#vars}}
+ * @param {{{name}}} {{#description}}{{{description}}}{{/description}}{{#example}} for example: '''{{{example}}}'''{{/example}}
+{{/vars}}
+ */
 case class {{classname}} (
   {{#vars}}
-  {{#description}}
-  // {{{description}}}
-  {{/description}}
   {{{name}}}: {{^required}}Option[{{/required}}{{datatype}}{{^required}}] = None{{/required}}{{#hasMore}},{{/hasMore}}
   {{/vars}}
 )

--- a/src/main/resources/mustache/scala/model.mustache
+++ b/src/main/resources/mustache/scala/model.mustache
@@ -20,7 +20,7 @@ import {{import}}
  */
 case class {{classname}} (
   {{#vars}}
-  {{{name}}}: {{^required}}Option[{{/required}}{{datatype}}{{^required}}] = None{{/required}}{{#hasMore}},{{/hasMore}}
+  {{{name}}}: {{^required}}Option[{{/required}}{{datatype}}{{^required}}]{{/required}}{{#hasMore}},{{/hasMore}}
   {{/vars}}
 )
 


### PR DESCRIPTION
-  Profit from the already provided documentation, by generating scala doc that includes examples and more
- Remove default parameters for options that are a common source of problems and add nothing to the implementation
 