### PR TITLE
set templateEngine default as Handlebars

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -151,7 +151,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
     protected String gitUserId, gitRepoId, releaseNote;
     protected String httpUserAgent;
     protected Boolean hideGenerationTimestamp = true;
-    protected TemplateEngine templateEngine = new MustacheTemplateEngine(this);;
+    protected TemplateEngine templateEngine = new HandlebarTemplateEngine(this);;
     // How to encode special characters like $
     // They are translated to words like "Dollar" and prefixed with '
     // Then translated back during JSON encoding and decoding
@@ -3663,7 +3663,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         String templateEngineKey = additionalProperties.get(CodegenConstants.TEMPLATE_ENGINE) != null ? additionalProperties.get(CodegenConstants.TEMPLATE_ENGINE).toString() : null;
 
         if (templateEngineKey == null) {
-            templateEngine = new MustacheTemplateEngine(this);
+            templateEngine = new HandlebarTemplateEngine(this);
         } else {
             if (CodegenConstants.HANDLEBARS_TEMPLATE_ENGINE.equalsIgnoreCase(templateEngineKey)) {
                 templateEngine = new HandlebarTemplateEngine(this);

--- a/src/test/java/io/swagger/codegen/v3/generators/java/JavaClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/JavaClientCodegenTest.java
@@ -254,7 +254,7 @@ public class JavaClientCodegenTest {
     public void customTemplates() throws Exception {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.processOpts();
-        Assert.assertEquals(codegen.templateDir(), "mustache" + File.separator  + "Java");
+        Assert.assertEquals(codegen.templateDir(), "handlebars" + File.separator  + "Java");
 
         codegen.additionalProperties().put(CodegenConstants.TEMPLATE_DIR, String.join(File.separator,"user", "custom", "location"));
         codegen.processOpts();

--- a/src/test/java/io/swagger/codegen/v3/generators/php/PhpClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/php/PhpClientCodegenTest.java
@@ -22,8 +22,8 @@ public class PhpClientCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.TRUE);
         Assert.assertEquals(codegen.getHideGenerationTimestamp(), Boolean.TRUE);
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
-        Assert.assertEquals(codegen.templateDir(), "mustache" + File.separator + "php");
-        Assert.assertEquals(codegen.embeddedTemplateDir(), "mustache" + File.separator + "php");
+        Assert.assertEquals(codegen.templateDir(), "handlebars" + File.separator + "php");
+        Assert.assertEquals(codegen.embeddedTemplateDir(), "handlebars" + File.separator + "php");
     }
 
     @Test
@@ -76,6 +76,6 @@ public class PhpClientCodegenTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.templateDir(), "/absolute/path");
-        Assert.assertEquals(codegen.embeddedTemplateDir(), "mustache" + File.separator + "php");
+        Assert.assertEquals(codegen.embeddedTemplateDir(), "handlebars" + File.separator + "php");
     }
 }


### PR DESCRIPTION
updates DefaultCodegenConfig to have handlebars as default template, and adjust JavaClient and PhpClient tests. This fixes build in `swagger-codegen`