### PR TITLE
[Angular] Fixed #170 "TypeScriptAngular: {{#isBodyAllowed}} not avail…

### DIFF
--- a/src/main/resources/mustache/typescript-angular/api.service.mustache
+++ b/src/main/resources/mustache/typescript-angular/api.service.mustache
@@ -309,8 +309,8 @@ export class {{classname}} {
 
 {{/hasFormParams}}
 {{#useHttpClient}}
-        return this.httpClient.{{httpMethod}}{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}(`${this.basePath}{{{path}}}`,{{#isBodyAllowed}}
-            {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}convertFormParamsToString ? formParams.toString() : formParams{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},{{/isBodyAllowed}}
+        return this.httpClient.{{httpMethod}}{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}(`${this.basePath}{{{path}}}`,{{#bodyAllowed}}
+            {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}convertFormParamsToString ? formParams.toString() : formParams{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},{{/bodyAllowed}}
             {
 {{#hasQueryParams}}
                 params: queryParameters,


### PR DESCRIPTION
…able in templates"

Fixes #170.
When the template engine finds the "isBodyAllowed" keyword inside mustache files, it tries to invoke a method named "getIsBodyAllowed" in CodegenOperation.java, but it's not there.
Instead, correctly, there's an "isBodyAllowed" method, that will be called if "bodyAllowed" is found in mustache files.
I checked other languages: ktor library for kotlin-server works the same and uses "bodyAllowed".
Therefore I simply changed "isBodyAllowed" to "bodyAllowed" in mustache files: now body is correctly injected in httpClient requests when body is allowed (PUT, PATCH and POST methods).
