### PR TITLE
Fixed #224 "The generated classes for services are invalid, because a…

### DIFF
--- a/src/main/resources/handlebars/typescript-angular/api.service.mustache
+++ b/src/main/resources/handlebars/typescript-angular/api.service.mustache
@@ -337,3 +337,4 @@ export class {{classname}} {
 
 {{/operation}}
 {{/operations}}
+}

--- a/src/main/resources/mustache/typescript-angular/api.service.mustache
+++ b/src/main/resources/mustache/typescript-angular/api.service.mustache
@@ -354,3 +354,4 @@ export class {{classname}} {
 
 {{/operation}}}
 {{/operations}}
+}


### PR DESCRIPTION
… curly brace is missing at the end"

Fixed #224.
Added missing curly brace at the end of generated services for both handlebars and mustache templates.