### PR TITLE
Update scala's model.mustache to set a default value of None for optional fields (as in 2.4)

### DIFF
--- a/src/main/resources/mustache/scala/client/model.mustache
+++ b/src/main/resources/mustache/scala/client/model.mustache
@@ -20,7 +20,7 @@ import {{import}}
  */
 case class {{classname}} (
   {{#vars}}
-  {{{name}}}: {{^required}}Option[{{/required}}{{datatype}}{{^required}}]{{/required}}{{#hasMore}},{{/hasMore}}
+  {{{name}}}: {{^required}}Option[{{/required}}{{datatype}}{{^required}}] = None{{/required}}{{#hasMore}},{{/hasMore}}
   {{/vars}}
 )
 


### PR DESCRIPTION
The missing default value of None for optional fields is critical for significantly less boilerplate code, and backwards compatibility with anyone using the previous version of swagger-codegen.
The line was copied from https://github.com/swagger-api/swagger-codegen/blob/master/modules/swagger-codegen/src/main/resources/scala/model.mustache