### PR TITLE
Fix swagger-codegen/issues/9126 [CSHARP] v3.x with csharp generator crashes when schema inheritence has length more than 2 

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -3760,7 +3760,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
     protected String getTemplateDir() {
         return new StringBuilder()
                 .append(templateEngine.getName())
-                .append("/")
+                .append(File.separator)
                 .append(getDefaultTemplateDir())
                 .toString();
     }


### PR DESCRIPTION
See attached a commit that causes the CSharp code generator not to crash anymore when generating code for http://developers.strava.com/swagger/swagger.json.
The generated code itself is still wrong, but I'm working on a fix for that as well.