### PR TITLE
[Java] Getter/Setter naming convention not followed in generated models (#8282)

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -1161,7 +1161,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
     }
 
     /**
-     * Output the Getter name, e.g. getSize
+     * Output the Setter name, e.g. setSize
      *
      * @param name the name of the property
      * @return setter name based on naming convention

--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -1314,11 +1314,13 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
     public void setSupportJava6(boolean value) {
         this.supportJava6 = value;
     }
-    
+
+    @Override
     public String toRegularExpression(String pattern) {
         return escapeText(pattern);
     }
 
+    @Override
     public boolean convertPropertyToBoolean(String propertyKey) {
         boolean booleanValue = false;
         if (additionalProperties.containsKey(propertyKey)) {
@@ -1328,6 +1330,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         return booleanValue;
     }
 
+    @Override
     public void writePropertyBack(String propertyKey, boolean value) {
         additionalProperties.put(propertyKey, value);
     }
@@ -1338,9 +1341,33 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
      * @param name the name of the property
      * @return getter name based on naming convention
      */
+    @Override
     public String toBooleanGetter(String name) {
         return "is" + getterAndSetterCapitalize(name);
     }
+
+    /**
+     * Output the partial Getter name for boolean property, e.g. Active
+     * Camelize the method name of the getter and setter for Java
+     * Except when the second letter of the field name is already uppercase
+     * Refer to section 8.8: Capitalization of inferred names of the JavaBeans API specification
+     * http://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf)
+     *
+     * @param name the name of the property
+     * @return partial getter name based on naming convention
+     * @param name string to be camelized
+     * @return Camelized string
+     */
+    @Override
+    public String getterAndSetterCapitalize(String name) {
+            if (name == null || name.length() == 0) {
+                return name;
+            }
+            if (name.length() > 1 && Character.isUpperCase(name.charAt(1))){
+                return name;
+            }
+            return camelize(toVarName(name));
+        }
 
     @Override
     public String sanitizeTag(String tag) {

--- a/src/test/java/io/swagger/codegen/v3/generators/java/JavaModelTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/JavaModelTest.java
@@ -450,8 +450,8 @@ public class JavaModelTest {
 
         final CodegenProperty property = cm.vars.get(0);
         Assert.assertEquals(property.baseName, "pId");
-        Assert.assertEquals(property.getter, "getPId");
-        Assert.assertEquals(property.setter, "setPId");
+        Assert.assertEquals(property.getter, "getpId");
+        Assert.assertEquals(property.setter, "setpId");
         Assert.assertEquals(property.datatype, "String");
         Assert.assertEquals(property.name, "pId");
         Assert.assertEquals(property.defaultValue, "null");
@@ -476,8 +476,8 @@ public class JavaModelTest {
 
         final CodegenProperty property = cm.vars.get(0);
         Assert.assertEquals(property.baseName, "ATTName");
-        Assert.assertEquals(property.getter, "getAtTName");
-        Assert.assertEquals(property.setter, "setAtTName");
+        Assert.assertEquals(property.getter, "getATTName");
+        Assert.assertEquals(property.setter, "setATTName");
         Assert.assertEquals(property.datatype, "String");
         Assert.assertEquals(property.name, "atTName");
         Assert.assertEquals(property.defaultValue, "null");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- (N/A) Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language. -> nobody for Java

### Description of the PR

[Java] Getter/Setter naming convention not followed in generated models (https://github.com/swagger-api/swagger-codegen/issues/8282)

fix the getter/setter when the second letter of the field name is already uppercase (following the JavaBeans API specification)

Details : 
Override `getterAndSetterCapitalize` class in the `JavaCodeGen` class
Change Java test `convert a model with a 2nd char upper-case property names` and `convert a model starting with two upper-case letter property names` (getter and setter expected results)

useful links : 
- https://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf?AuthParam=1548672501_cd9f95cc049ee0220b70f6c448b2a095 (chapter 8)
- https://dertompson.com/2013/04/29/java-bean-getterssetters/
