### PR TITLE
When adding CodegenParameter to multiple lists, ensure it is copied f…

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -2024,7 +2024,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
                             }
                             // todo: this segment is only to support the "older" template design. it should be removed once all templates are updated with the new {{#contents}} tag.
                             formParameter.getVendorExtensions().put(CodegenConstants.IS_FORM_PARAM_EXT_NAME, Boolean.TRUE);
-                            formParams.add(formParameter);
+                            formParams.add(formParameter.copy());
                             allParams.add(formParameter);
 
                             codegenContent.getParameters().add(formParameter.copy());
@@ -2035,7 +2035,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
                     bodyParam = fromRequestBody(body, schemaName, schema, schemas, imports);
                     if (foundSchemas.isEmpty()) {
                         // todo: this segment is only to support the "older" template design. it should be removed once all templates are updated with the new {{#contents}} tag.
-                        bodyParams.add(bodyParam);
+                        bodyParams.add(bodyParam.copy());
                         allParams.add(bodyParam);
                     } else {
                         boolean alreadyAdded = false;


### PR DESCRIPTION
…irst.

Compiled and then tested with latest `swagger-codegen` branch `3.0.0` with the described change to the petstore...yaml.

Closes #297 