### PR TITLE
Fix: x-has-more not working for request body properly

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -2035,7 +2035,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
                     bodyParam = fromRequestBody(body, schemaName, schema, schemas, imports);
                     if (foundSchemas.isEmpty()) {
                         // todo: this segment is only to support the "older" template design. it should be removed once all templates are updated with the new {{#contents}} tag.
-                        bodyParams.add(bodyParam);
+                        bodyParams.add(bodyParam.copy());
                         allParams.add(bodyParam);
                     } else {
                         boolean alreadyAdded = false;


### PR DESCRIPTION
This fixes the problem that the vendor extension `x-has-more` doesn't work properly for request bodies. 

The reason is that the same `bodyParam` instance is added to both the `bodyParams` and the `allParams` collection. Then, later this is done:

```java
codegenOperation.allParams = addHasMore(allParams);
codegenOperation.bodyParams = addHasMore(bodyParams);
```

The second line will set the vendor extension `x-has-more` to `false` for the last body param - even if it's not the last param in `allParams`. And that's wrong.