### PR TITLE
Fixed consumes list not being resolved when request body is specified via reference (rather than inline)

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -1890,7 +1890,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
             codegenOperation.getVendorExtensions().put(CodegenConstants.IS_DEPRECATED_EXT_NAME, operation.getDeprecated());
         }
 
-        addConsumesInfo(operation, codegenOperation);
+        addConsumesInfo(operation, codegenOperation, openAPI);
 
         if (operation.getResponses() != null && !operation.getResponses().isEmpty()) {
             ApiResponse methodResponse = findMethodResponse(operation.getResponses());
@@ -3805,11 +3805,21 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         }
     }
 
-    protected void addConsumesInfo(Operation operation, CodegenOperation codegenOperation) {
-        if(operation.getRequestBody() == null || operation.getRequestBody().getContent() == null || operation.getRequestBody().getContent().isEmpty()) {
+    protected void addConsumesInfo(Operation operation, CodegenOperation codegenOperation, OpenAPI openAPI) {
+        RequestBody body = operation.getRequestBody();
+        if (body == null) {
             return;
         }
-        Set<String> consumes = operation.getRequestBody().getContent().keySet();
+        if (StringUtils.isNotBlank(body.get$ref())) {
+            String bodyName = OpenAPIUtil.getSimpleRef(body.get$ref());
+            body = openAPI.getComponents().getRequestBodies().get(bodyName);
+        }
+        
+        if (body.getContent() == null || body.getContent().isEmpty()) {
+            return;
+        }
+        
+        Set<String> consumes = body.getContent().keySet();
         List<Map<String, String>> mediaTypeList = new ArrayList<>();
         int count = 0;
         for (String key : consumes) {

--- a/src/test/java/io/swagger/codegen/v3/generators/DefaultCodegenConfigTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/DefaultCodegenConfigTest.java
@@ -17,14 +17,13 @@ import io.swagger.v3.oas.models.media.NumberSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.parser.OpenAPIV3Parser;
 
 import org.testng.Assert;
-import org.testng.ITestContext;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 
@@ -168,6 +167,25 @@ public class DefaultCodegenConfigTest {
         };
     }
     
+    /**
+     * Tests that {@link DefaultCodegenConfig#fromOperation(String, String, Operation, java.util.Map, OpenAPI)} correctly
+     * resolves the consumes list when the request body is specified via reference rather than inline.
+     */
+    @Test
+    public void testRequestBodyRefConsumesList() {
+        final OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/resources/3_0_0/requestBodyRefTest.json");
+        final P_DefaultCodegenConfig codegen = new P_DefaultCodegenConfig(); 
+        final String path = "/test/requestBodyRefTest";
+        final Operation op = openAPI.getPaths().get(path).getPost();
+        final CodegenOperation codegenOp = codegen.fromOperation(path, "post", op, openAPI.getComponents().getSchemas(), openAPI);
+
+        Assert.assertTrue(codegenOp.getHasConsumes());
+        Assert.assertNotNull(codegenOp.consumes);
+        Assert.assertEquals(codegenOp.consumes.size(), 2);
+        Assert.assertEquals(codegenOp.consumes.get(0).get("mediaType"), "application/json");
+        Assert.assertEquals(codegenOp.consumes.get(1).get("mediaType"), "application/xml");
+    }
+
     private static class P_DefaultCodegenConfig extends DefaultCodegenConfig{
         @Override
         public String getArgumentsLocation() {

--- a/src/test/resources/3_0_0/requestBodyRefTest.json
+++ b/src/test/resources/3_0_0/requestBodyRefTest.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Api",
+    "version": "3.0.0"
+  },
+  "paths": {
+    "/test/requestBodyRefTest": {
+      "post": {
+        "summary": "Test method",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Pet"
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "Pet": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "string"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #302 .

The only thing I could not figure out is what should happen if the `openAPI` parameter is `null`. The current codes throws a `NullPointerException` - the same behavior as `fromOperation()`.