### PR TITLE
Fixed "getCollectionFormat()"

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -3925,13 +3925,16 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         return null;
     }
 
+    // See: https://swagger.io/docs/specification/serialization/#query
     protected String getCollectionFormat(Parameter parameter) {
-        if (Parameter.StyleEnum.FORM.equals(parameter.getStyle())) {
-            if (parameter.getExplode() != null && parameter.getExplode()) {
-                return "csv";
-            } else {
-                return "multi";
-            }
+        // "explode: true" is the default and always results in "multi", no matter the style.
+        if (parameter.getExplode() == null || parameter.getExplode()) {
+            return "multi";
+        }
+        
+        // Form is the default, if no style is specified.
+        if (parameter.getStyle() == null || Parameter.StyleEnum.FORM.equals(parameter.getStyle())) {
+            return "csv";
         }
         else if (Parameter.StyleEnum.PIPEDELIMITED.equals(parameter.getStyle())) {
             return "pipe";


### PR DESCRIPTION
The current implementation of `DefaultCodegenConfig.getCollectionFormat()` is wrong. It doesn't match the behavior specified here:

https://swagger.io/docs/specification/serialization/#query

Especially:

* When `style` is `FORM` and `explode` is `true`, `csv` is returned instead of `multi`.
* When `style` is not `FORM` and `explode` is `true`, the "style value" is returned instead of `multi`. The "style value" should only be returned if `explode` is `false`.