### PR TITLE
Fixed issue with retrofit2 generator fail

### DIFF
--- a/src/main/resources/handlebars/Java/libraries/retrofit2/api_test.mustache
+++ b/src/main/resources/handlebars/Java/libraries/retrofit2/api_test.mustache
@@ -28,7 +28,7 @@ public class {{classname}}Test {
     {{#operations}}
     {{#operation}}
     {{#contents}}
-    {{#@ƒirst}}
+    {{#@first}}
 
     /**
      * {{summary}}
@@ -44,7 +44,7 @@ public class {{classname}}Test {
 
         // TODO: test validations
     }
-    {{/@ƒirst}}
+    {{/@first}}
     {{/contents}}
     {{/operation}}
     {{/operations}}


### PR DESCRIPTION
For some reason, there was `ƒ` instead of `f` in `  {{#@first}}{{/@first}}`. And thus generating always fails because of this.

Stack trace: 

```
om.github.jknack.handlebars.internal.HbsParserFactory - Building AST
Exception in thread "Thread-1" java.lang.RuntimeException: Could not generate api file for 'Application'
	at io.swagger.codegen.v3.DefaultGenerator.generateApis(DefaultGenerator.java:523)
	at io.swagger.codegen.v3.DefaultGenerator.generate(DefaultGenerator.java:722)
	at io.swagger.codegen.v3.cli.cmd.Generate.run(Generate.java:342)
	at java.lang.Thread.run(Thread.java:748)
Caused by: com.github.jknack.handlebars.HandlebarsException: /handlebars/Java/libraries/retrofit2/api_test.mustache:31:8: found: 'ƒ'
    {{#@ƒirst}}
        ^

	at com.github.jknack.handlebars.internal.HbsErrorReporter.syntaxError(HbsErrorReporter.java:93)
	at org.antlr.v4.runtime.ProxyErrorListener.syntaxError(ProxyErrorListener.java:65)
	at com.github.jknack.handlebars.internal.HbsParserFactory$2.notifyListeners(HbsParserFactory.java:148)
	at org.antlr.v4.runtime.Lexer.nextToken(Lexer.java:168)
	at org.antlr.v4.runtime.BufferedTokenStream.fetch(BufferedTokenStream.java:185)
	at org.antlr.v4.runtime.BufferedTokenStream.sync(BufferedTokenStream.java:168)
	at org.antlr.v4.runtime.BufferedTokenStream.consume(BufferedTokenStream.java:152)
	at org.antlr.v4.runtime.Parser.consume(Parser.java:593)
	at org.antlr.v4.runtime.Parser.match(Parser.java:226)
	at com.github.jknack.handlebars.internal.HbsParser.sexpr(HbsParser.java:884)
	at com.github.jknack.handlebars.internal.HbsParser.block(HbsParser.java:657)
	at com.github.jknack.handlebars.internal.HbsParser.statement(HbsParser.java:336)
	at com.github.jknack.handlebars.internal.HbsParser.body(HbsParser.java:222)
	at com.github.jknack.handlebars.internal.HbsParser.block(HbsParser.java:670)
	at com.github.jknack.handlebars.internal.HbsParser.statement(HbsParser.java:336)
	at com.github.jknack.handlebars.internal.HbsParser.body(HbsParser.java:222)
	at com.github.jknack.handlebars.internal.HbsParser.block(HbsParser.java:670)
	at com.github.jknack.handlebars.internal.HbsParser.statement(HbsParser.java:336)
	at com.github.jknack.handlebars.internal.HbsParser.body(HbsParser.java:222)
	at com.github.jknack.handlebars.internal.HbsParser.block(HbsParser.java:670)
	at com.github.jknack.handlebars.internal.HbsParser.statement(HbsParser.java:336)
	at com.github.jknack.handlebars.internal.HbsParser.body(HbsParser.java:222)
	at com.github.jknack.handlebars.internal.HbsParser.template(HbsParser.java:165)
	at com.github.jknack.handlebars.internal.HbsParserFactory$1.parse(HbsParserFactory.java:84)
	at com.github.jknack.handlebars.cache.NullTemplateCache.get(NullTemplateCache.java:54)
	at com.github.jknack.handlebars.Handlebars.compile(Handlebars.java:414)
	at com.github.jknack.handlebars.Handlebars.compile(Handlebars.java:357)
	at com.github.jknack.handlebars.Handlebars.compile(Handlebars.java:343)
	at io.swagger.codegen.v3.templates.HandlebarTemplateEngine.getHandlebars(HandlebarTemplateEngine.java:48)
	at io.swagger.codegen.v3.templates.HandlebarTemplateEngine.getRendered(HandlebarTemplateEngine.java:24)
	at io.swagger.codegen.v3.DefaultGenerator.processTemplateToFile(DefaultGenerator.java:735)
	at io.swagger.codegen.v3.DefaultGenerator.generateApis(DefaultGenerator.java:498)
	... 3 more
```