### PR TITLE
Mark form parameters as required when body is required

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -2033,6 +2033,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
                         for (String propertyName : propertyMap.keySet()) {
                             CodegenParameter formParameter = fromParameter(new Parameter()
                                     .name(propertyName)
+                                    .required(body.getRequired())
                                     .schema(propertyMap.get(propertyName)), imports);
                             if (isMultipart) {
                                 formParameter.getVendorExtensions().put(CodegenConstants.IS_MULTIPART_EXT_NAME, Boolean.TRUE);
@@ -2040,6 +2041,9 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
                             // todo: this segment is only to support the "older" template design. it should be removed once all templates are updated with the new {{#contents}} tag.
                             formParameter.getVendorExtensions().put(CodegenConstants.IS_FORM_PARAM_EXT_NAME, Boolean.TRUE);
                             formParams.add(formParameter.copy());
+                            if (body.getRequired()) {
+                                requiredParams.add(formParameter.copy());
+                            }
                             allParams.add(formParameter);
 
                             codegenContent.getParameters().add(formParameter.copy());

--- a/src/test/java/io/swagger/codegen/v3/generators/DefaultCodegenConfigTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/DefaultCodegenConfigTest.java
@@ -186,6 +186,77 @@ public class DefaultCodegenConfigTest {
         Assert.assertEquals(codegenOp.consumes.get(1).get("mediaType"), "application/xml");
     }
 
+    /**
+     * Tests when a 'application/x-www-form-urlencoded' request body is marked as required that all form
+     * params are also marked as required.
+     * 
+     * @see #testOptionalFormParams()
+     */
+    @Test
+    public void testRequiredFormParams() {
+        // Setup
+        final P_DefaultCodegenConfig codegen = new P_DefaultCodegenConfig(); 
+
+        final OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/resources/3_0_0/requiredFormParamsTest.yaml");
+        final String path = "/test_required";
+        
+        final Operation op = openAPI.getPaths().get(path).getPost();
+        Assert.assertNotNull(op);
+        
+        // Test
+        final CodegenOperation codegenOp = codegen.fromOperation(path, "post", op, openAPI.getComponents().getSchemas(), openAPI);
+        
+        // Verification
+        List<CodegenParameter> formParams = codegenOp.getFormParams();
+        Assert.assertNotNull(formParams);
+        Assert.assertEquals(formParams.size(), 2);
+        
+        for (CodegenParameter formParam : formParams) {
+            Assert.assertTrue(formParam.getRequired(), "Form param '" + formParam.getParamName() + "' is not required.");
+        }
+
+        // Required params must be updated as well.
+        List<CodegenParameter> requiredParams = codegenOp.getRequiredParams();
+        Assert.assertNotNull(requiredParams);
+        Assert.assertEquals(requiredParams.size(), 2);
+        requiredParams.get(0).getParamName().equals("id");
+        requiredParams.get(1).getParamName().equals("name");
+    }
+
+    /**
+     * Tests when a 'application/x-www-form-urlencoded' request body is marked as optional that all form
+     * params are also marked as optional.
+     * 
+     * @see #testRequiredFormParams()
+     */
+    @Test
+    public void testOptionalFormParams() {
+        // Setup
+        final P_DefaultCodegenConfig codegen = new P_DefaultCodegenConfig(); 
+
+        final OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/resources/3_0_0/requiredFormParamsTest.yaml");
+        final String path = "/test_optional";
+        
+        final Operation op = openAPI.getPaths().get(path).getPost();
+        Assert.assertNotNull(op);
+        
+        // Test
+        final CodegenOperation codegenOp = codegen.fromOperation(path, "post", op, openAPI.getComponents().getSchemas(), openAPI);
+        
+        // Verification
+        List<CodegenParameter> formParams = codegenOp.getFormParams();
+        Assert.assertNotNull(formParams);
+        Assert.assertEquals(formParams.size(), 2);
+        
+        for (CodegenParameter formParam : formParams) {
+            Assert.assertFalse(formParam.getRequired(), "Form param '" + formParam.getParamName() + "' is required.");
+        }
+
+        // Required params must be updated as well.
+        List<CodegenParameter> requiredParams = codegenOp.getRequiredParams();
+        Assert.assertTrue(requiredParams == null || requiredParams.size() == 0);
+    }
+    
     private static class P_DefaultCodegenConfig extends DefaultCodegenConfig{
         @Override
         public String getArgumentsLocation() {

--- a/src/test/resources/3_0_0/requiredFormParamsTest.yaml
+++ b/src/test/resources/3_0_0/requiredFormParamsTest.yaml
@@ -20,8 +20,8 @@ paths:
 
   /test_optional:
     post:
-      summary: Operation with form body that is required
-      operationId: get_with_required_body
+      summary: Operation with form body that is optional
+      operationId: get_with_optional_body
       requestBody:
         required: false
         content:

--- a/src/test/resources/3_0_0/requiredFormParamsTest.yaml
+++ b/src/test/resources/3_0_0/requiredFormParamsTest.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.0
+info:
+  title: Test Api
+  version: '3.0.0'
+
+paths:
+  /test_required:
+    post:
+      summary: Operation with form body that is required
+      operationId: get_with_required_body
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Category'
+      responses:
+        "200":
+          description: Success
+
+  /test_optional:
+    post:
+      summary: Operation with form body that is required
+      operationId: get_with_required_body
+      requestBody:
+        required: false
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Category'
+      responses:
+        "200":
+          description: Success
+
+components:
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string


### PR DESCRIPTION
This pull request fixes the problem that when a form request body is marked as "required", then all form parameters should also be marked as "required".

For example, take this (shortened) input spec:

```yaml
paths:
  /test_required:
    post:
      summary: Operation with form body that is required
      requestBody:
        required: true
        content:
          application/x-www-form-urlencoded:
            schema:
              $ref: '#/components/schemas/Category'

components:
  schemas:
    Category:
      type: object
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
```

It results in 2 form parameters (`id` and `name`). Without this fix both parameters would be marked as "optional", even though the request body is marked as "required".