### PR TITLE
Fix generated python api imports to include packageName.

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
@@ -254,6 +254,16 @@ public class PythonClientCodegen extends DefaultCodegenConfig {
     }
 
     @Override
+    public String toApiImport(String name) {
+        String apiImport = "";
+        if (!"".equals(apiPackage())) {
+            apiImport += apiPackage() + ".";
+        }
+        apiImport += toApiFilename(name);
+        return apiImport;
+    }
+
+    @Override
     public Map<String, Object> postProcessModels(Map<String, Object> objs) {
         // process enum in models
         return postProcessModelsEnum(objs);

--- a/src/main/resources/handlebars/python/__init__api.mustache
+++ b/src/main/resources/handlebars/python/__init__api.mustache
@@ -3,5 +3,5 @@ from __future__ import absolute_import
 # flake8: noqa
 
 # import apis into api package
-{{#apiInfo}}{{#apis}}from {{apiPackage}}.{{classVarName}} import {{classname}}
+{{#apiInfo}}{{#apis}}from {{importPath}} import {{classname}}
 {{/apis}}{{/apiInfo}}

--- a/src/main/resources/handlebars/python/__init__package.mustache
+++ b/src/main/resources/handlebars/python/__init__package.mustache
@@ -7,7 +7,7 @@
 from __future__ import absolute_import
 
 # import apis into sdk package
-{{#apiInfo}}{{#apis}}from {{apiPackage}}.{{classVarName}} import {{classname}}
+{{#apiInfo}}{{#apis}}from {{importPath}} import {{classname}}
 {{/apis}}{{/apiInfo}}
 # import ApiClient
 from {{packageName}}.api_client import ApiClient


### PR DESCRIPTION
Generate base python package import does not work at all (tested with python 3.7).
This PR fixes the generated importPath to correctly include the base package name. 
