### PR TITLE
Typescript import must use / as path separator in every operating system

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/typescript/TypeScriptAngularClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/typescript/TypeScriptAngularClientCodegen.java
@@ -127,6 +127,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         additionalProperties.put("injectionToken", ngVersion.atLeast("4.0.0") ? "InjectionToken" : "OpaqueToken");
         additionalProperties.put("injectionTokenTyped", ngVersion.atLeast("4.0.0"));
         additionalProperties.put("useHttpClient", ngVersion.atLeast("4.3.0"));
+        additionalProperties.put("useRxJS6", ngVersion.atLeast("6.0.0"));
         if (!ngVersion.atLeast("4.3.0")) {
             supportingFiles.add(new SupportingFile("rxjs-operators.mustache", getIndexDirectory(), "rxjs-operators.ts"));
         }

--- a/src/main/java/io/swagger/codegen/v3/generators/typescript/TypeScriptAngularClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/typescript/TypeScriptAngularClientCodegen.java
@@ -368,7 +368,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
     @Override
     public String toApiImport(String name) {
-        return apiPackage() + File.separator + toApiFilename(name);
+        return apiPackage() + "/" + toApiFilename(name);
     }
 
     @Override
@@ -378,7 +378,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
     @Override
     public String toModelImport(String name) {
-        return modelPackage() + File.separator + toModelFilename(name);
+        return modelPackage() + "/" + toModelFilename(name);
     }
 
     public String getNpmName() {


### PR DESCRIPTION
Typescript import must use / as path separator in every operating system.

Using File.separator in Windows generates invalid typescript code:

### Before:
`import { MailService } from './api\mail.service';`  <- Invalid

### After:
`import { MailService } from './api/mail.service';`  <- correct in every operating system
