### PR TITLE
Added support for ApiKeys with location 'cookie' in RestTemplate client codegen

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -2643,9 +2643,9 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
                 codegenSecurity.keyParamName = schemeDefinition.getName();
                 codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_API_KEY_EXT_NAME, Boolean.TRUE);
 
-                boolean isKeyInHeader = schemeDefinition.getIn() == SecurityScheme.In.HEADER;
-                codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_KEY_IN_HEADER_EXT_NAME, isKeyInHeader);
-                codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_KEY_IN_QUERY_EXT_NAME, !isKeyInHeader);
+                codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_KEY_IN_HEADER_EXT_NAME, schemeDefinition.getIn() == SecurityScheme.In.HEADER);
+                codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_KEY_IN_COOKIE_EXT_NAME, schemeDefinition.getIn() == SecurityScheme.In.COOKIE);
+                codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_KEY_IN_QUERY_EXT_NAME, schemeDefinition.getIn() == SecurityScheme.In.QUERY);
 
             } else if (SecurityScheme.Type.HTTP.equals(schemeDefinition.getType())) {
                 if ("bearer".equalsIgnoreCase(schemeDefinition.getScheme())) {

--- a/src/main/resources/handlebars/Java/libraries/resttemplate/ApiClient.mustache
+++ b/src/main/resources/handlebars/Java/libraries/resttemplate/ApiClient.mustache
@@ -122,7 +122,7 @@ public class ApiClient {
         // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();{{#authMethods}}{{#is this 'basic'}}
     authentications.put("{{name}}", new HttpBasicAuth());{{/is}}{{#is this 'api-key'}}
-    authentications.put("{{name}}", new ApiKeyAuth({{#is this 'key-in-header'}}"header"{{/is}}{{#isNot this 'key-in-header'}}"query"{{/isNot}}, "{{keyParamName}}"));{{/is}}{{#is this 'oauth'}}
+    authentications.put("{{name}}", new ApiKeyAuth({{#is this 'key-in-header'}}"header"{{/is}}{{#is this 'key-in-cookie'}}"cookie"{{/is}}{{#is this 'key-in-query'}}"query"{{/is}}, "{{keyParamName}}"));{{/is}}{{#is this 'oauth'}}
     authentications.put("{{name}}", new OAuth());{{/is}}{{#is this 'bearer'}}
     authentications.put("{{name}}", new OAuth());{{/is}}{{/authMethods}}
         // Prevent the authentications from being modified.

--- a/src/main/resources/handlebars/Java/libraries/resttemplate/auth/ApiKeyAuth.mustache
+++ b/src/main/resources/handlebars/Java/libraries/resttemplate/auth/ApiKeyAuth.mustache
@@ -55,6 +55,8 @@ public class ApiKeyAuth implements Authentication {
             queryParams.add(paramName, value);
         } else if (location.equals("header")) {
             headerParams.add(paramName, value);
-       }
+        } else if (location.equals("cookie")) {
+            headerParams.add("Cookie", String.format("%s=%s", paramName, value));
+        }
     }
 }


### PR DESCRIPTION
The PR adds support to the Java RestTemplate client generator for cookie-based ApiKeys.
It only works with PR swagger-api/swagger-codegen#9371 because it needs a constant definition in swagger-coden