### PR TITLE
Replace dataType with baseType+containerType to fix compilation error in AkkaHttpServerCodegen

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegen.java
@@ -72,9 +72,9 @@ public class AkkaHttpServerCodegen extends AbstractScalaCodegen  {
         Boolean hasComplexTypes = Boolean.FALSE;
         Boolean hasCookieParams = Boolean.FALSE;
         Set<String> complexRequestTypes = new HashSet<>();
-        Set<String> complexReturnTypes = new HashSet<>();
+        List<CodegenResponse> complexReturnTypes = new ArrayList<>();
         for (CodegenOperation op : operationList) {
-            Set<String> complexOperationReturnTypes = new HashSet<>();
+            List<CodegenResponse> complexOperationReturnTypes = new ArrayList<>();
             for(CodegenParameter parameter : op.allParams) {
                 if(!parameter.getIsPrimitiveType()){
                     if(parameter.getIsBodyParam()){
@@ -89,8 +89,8 @@ public class AkkaHttpServerCodegen extends AbstractScalaCodegen  {
             for(CodegenResponse response : op.responses) {
                 if(!response.getIsPrimitiveType()){
                     hasComplexTypes = Boolean.TRUE;
-                    complexReturnTypes.add(response.dataType);
-                    complexOperationReturnTypes.add(response.dataType);
+                    complexReturnTypes.add(response);
+                    complexOperationReturnTypes.add(response);
                 }
             }
             op.getVendorExtensions().put("complexReturnTypes", complexOperationReturnTypes);

--- a/src/main/resources/mustache/scala/akka-http-server/api.mustache
+++ b/src/main/resources/mustache/scala/akka-http-server/api.mustache
@@ -42,15 +42,15 @@ class {{classname}}(
 trait {{classname}}Service {
 
 {{#operation}}
-{{#responses}}  def {{operationId}}{{code}}{{#dataType}}(response{{dataType}}: {{dataType}}){{^isPrimitiveType}}(implicit toEntityMarshaller{{dataType}}: ToEntityMarshaller[{{dataType}}]){{/isPrimitiveType}}{{/dataType}}: Route =
-    complete(({{code}}, {{#dataType}}response{{dataType}}{{/dataType}}{{^dataType}}"{{message}}"{{/dataType}}))
+{{#responses}}  def {{operationId}}{{code}}{{#baseType}}(response{{baseType}}{{containerType}}: {{dataType}}){{^isPrimitiveType}}(implicit toEntityMarshaller{{baseType}}{{containerType}}: ToEntityMarshaller[{{dataType}}]){{/isPrimitiveType}}{{/baseType}}: Route =
+    complete(({{code}}, {{#baseType}}response{{baseType}}{{containerType}}{{/baseType}}{{^baseType}}"{{message}}"{{/baseType}}))
 {{/responses}}
   /**
 {{#responses}}   * {{#code}}Code: {{.}}{{/code}}{{#message}}, Message: {{.}}{{/message}}{{#dataType}}, DataType: {{.}}{{/dataType}}
    {{/responses}}
    */
   def {{operationId}}({{#vendorExtensions.paramsWithSupportedType}}{{paramName}}: {{^required}}{{^isBodyParam}}Option[{{/isBodyParam}}{{/required}}{{dataType}}{{^required}}{{^isBodyParam}}]{{/isBodyParam}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.paramsWithSupportedType}}){{^vendorExtensions.complexReturnTypes.isEmpty}}
-      (implicit {{#vendorExtensions.complexReturnTypes}}toEntityMarshaller{{.}}: ToEntityMarshaller[{{.}}]{{^-last}}, {{/-last}}{{/vendorExtensions.complexReturnTypes}}){{/vendorExtensions.complexReturnTypes.isEmpty}}: Route
+      (implicit {{#vendorExtensions.complexReturnTypes}}toEntityMarshaller{{baseType}}{{containerType}}: ToEntityMarshaller[{{dataType}}]{{^-last}}, {{/-last}}{{/vendorExtensions.complexReturnTypes}}){{/vendorExtensions.complexReturnTypes.isEmpty}}: Route
 
 {{/operation}}
 }
@@ -61,7 +61,7 @@ trait {{classname}}Marshaller {
 
 {{/complexRequestTypes}}
 
-{{#complexReturnTypes}}  implicit def toEntityMarshaller{{.}}: ToEntityMarshaller[{{.}}]
+{{#complexReturnTypes}}  implicit def toEntityMarshaller{{baseType}}{{containerType}}: ToEntityMarshaller[{{dataType}}]
 
 {{/complexReturnTypes}}
 }

--- a/src/test/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegenTest.java
@@ -80,9 +80,9 @@ public class AkkaHttpServerCodegenTest {
 
         Assert.assertEquals(result.get("hasComplexTypes"), Boolean.TRUE);
         Assert.assertEquals(result.get("complexRequestTypes"), new HashSet<String>(){{addAll(Arrays.asList("Pet","User"));}});
-        Assert.assertEquals(result.get("complexReturnTypes"), new HashSet<String>(){{addAll(Arrays.asList("Pet","User"));}});
-        Assert.assertEquals(codegenOperation1.getVendorExtensions().get("complexReturnTypes"), new HashSet<String>(){{addAll(Collections.singletonList("Pet"));}});
-        Assert.assertEquals(codegenOperation2.getVendorExtensions().get("complexReturnTypes"), new HashSet<String>(){{addAll(Arrays.asList("Pet","User"));}});
+        Assert.assertEquals(result.get("complexReturnTypes"), new LinkedList<CodegenResponse>(){{addAll(Arrays.asList(response1, response2, response3));}});
+        Assert.assertEquals(codegenOperation1.getVendorExtensions().get("complexReturnTypes"), new LinkedList<CodegenResponse>(){{add(response1);}});
+        Assert.assertEquals(codegenOperation2.getVendorExtensions().get("complexReturnTypes"), new LinkedList<CodegenResponse>(){{addAll(Arrays.asList(response1, response3));}});
     }
 
     @Test


### PR DESCRIPTION
Current version of `scala-akka-http-server` generator doesn't produce correct code if the response type is `array`. For example, for petstore it produces 

```scala
def findPetsByStatus200(responseList[Pet]: List[Pet])
(implicit toEntityMarshallerList[Pet]: ToEntityMarshaller[List[Pet]]): Route =
   complete((200, responseList[Pet]))
```

This code is not valid because `responseList[Pet]` etc contains the type with brackets (`{{dataType}}` in `api.mustache` templates).

This PR fixes this by using `{{baseType}}{{containerType}}` instead, which produces:
```scala
def findPetsByStatus200(responsePetarray: List[Pet])
(implicit toEntityMarshallerPetarray: ToEntityMarshaller[List[Pet]]): Route =  
   complete((200, responsePetarray))
```

I had to change the type of `complexReturnTypes` from `Set<String>` to `List<CodegenResponse>`, which is necessary as far as I understand the code.

I'm not a Java developer, and it's the first time I use this project, so please let me know if something can be improved.