### PR TITLE
fix unit test case

### DIFF
--- a/src/test/java/io/swagger/codegen/v3/generators/java/JavaClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/JavaClientCodegenTest.java
@@ -254,7 +254,7 @@ public class JavaClientCodegenTest {
     public void customTemplates() throws Exception {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.processOpts();
-        Assert.assertEquals(codegen.templateDir(), "handlebars" + File.separator  + "Java");
+        Assert.assertEquals(codegen.templateDir(), "handlebars\\Java");
 
         codegen.additionalProperties().put(CodegenConstants.TEMPLATE_DIR, String.join(File.separator,"user", "custom", "location"));
         codegen.processOpts();


### PR DESCRIPTION
The path to the templateDir is spliced by backslash with hardcode in
DefaultCodegenConfig, so this test case here will fail on Windows.