### PR TITLE
fix unit test cases with wrong expect path

### DIFF
--- a/src/test/java/io/swagger/codegen/v3/generators/java/JavaClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/JavaClientCodegenTest.java
@@ -254,7 +254,7 @@ public class JavaClientCodegenTest {
     public void customTemplates() throws Exception {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.processOpts();
-        Assert.assertEquals(codegen.templateDir(), "handlebars" + File.separator  + "Java");
+        Assert.assertEquals(codegen.templateDir(), "handlebars/Java");
 
         codegen.additionalProperties().put(CodegenConstants.TEMPLATE_DIR, String.join(File.separator,"user", "custom", "location"));
         codegen.processOpts();

--- a/src/test/java/io/swagger/codegen/v3/generators/php/PhpClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/php/PhpClientCodegenTest.java
@@ -22,8 +22,8 @@ public class PhpClientCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.TRUE);
         Assert.assertEquals(codegen.getHideGenerationTimestamp(), Boolean.TRUE);
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
-        Assert.assertEquals(codegen.templateDir(), "handlebars" + File.separator + "php");
-        Assert.assertEquals(codegen.embeddedTemplateDir(), "handlebars" + File.separator + "php");
+        Assert.assertEquals(codegen.templateDir(), "handlebars/php");
+        Assert.assertEquals(codegen.embeddedTemplateDir(), "handlebars/php");
     }
 
     @Test
@@ -76,6 +76,6 @@ public class PhpClientCodegenTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.templateDir(), "/absolute/path");
-        Assert.assertEquals(codegen.embeddedTemplateDir(), "handlebars" + File.separator + "php");
+        Assert.assertEquals(codegen.embeddedTemplateDir(), "handlebars/php");
     }
 }


### PR DESCRIPTION
The path to the templateDir is spliced by backslash with hardcode in
DefaultCodegenConfig, so these test cases here will fail on Windows.