### PR TITLE
Pass subclass specific properties to template as vars

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -1437,6 +1437,12 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
     }
 
     protected void addProperties(Map<String, Schema> properties, List<String> required, Schema schema, Map<String, Schema> allSchemas) {
+        if(schema.getProperties() != null) {
+            properties.putAll(schema.getProperties());
+        }
+        if(schema.getRequired() != null) {
+            required.addAll(schema.getRequired());
+        }
         if(schema instanceof ComposedSchema) {
             ComposedSchema composedSchema = (ComposedSchema) schema;
             if(composedSchema.getAllOf() == null || composedSchema.getAllOf().isEmpty() || composedSchema.getAllOf().size() == 1) {
@@ -1451,12 +1457,6 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
             Schema interfaceSchema = allSchemas.get(OpenAPIUtil.getSimpleRef(schema.get$ref()));
             addProperties(properties, required, interfaceSchema, allSchemas);
             return;
-        }
-        if(schema.getProperties() != null) {
-            properties.putAll(schema.getProperties());
-        }
-        if(schema.getRequired() != null) {
-            required.addAll(schema.getRequired());
         }
     }
 


### PR DESCRIPTION
Models with class inheritance are not rendered correctly in any language. When rendering a template, `DefaultCodegenConfig` does not pass subclass properties as `vars` param.

For example, if there are my models (JSON OpenAPI specification v3):
```
{
  "schemas": {
    "BaseClass": {
      "type": "object",
      "properties": {
        "baseProperty": {
          "type": "string"
        }
      }
    },
    "SubClass": {
      "type": "object",
      "properties": {
        "subProperty": {
          "type": "string"
        }
      },
      "allOf": [
        {
          "$ref": "#/components/schemas/BaseClass"
        }
      ]
    }
  }
}
```
then `SubClass` will be rendered without `subProperty`.

This change fixes the issue and renders subclasses correctly.