### PR TITLE
Fixe python model template to work with inheritance

### DIFF
--- a/src/main/resources/handlebars/python/model.mustache
+++ b/src/main/resources/handlebars/python/model.mustache
@@ -40,21 +40,35 @@ class {{classname}}({{#parent}}{{parent}}{{/parent}}{{^parent}}object{{/parent}}
         '{{name}}': '{{{datatype}}}'{{#hasMore}},{{/hasMore}}
 {{/vars}}
     }
+{{#parent}}
+    if hasattr({{parent}}, "swagger_types"):
+        swagger_types.update({{parent}}.swagger_types)
+{{/parent}}
 
     attribute_map = {
 {{#vars}}
         '{{name}}': '{{baseName}}'{{#hasMore}},{{/hasMore}}
 {{/vars}}
     }
+{{#parent}}
+    if hasattr({{parent}}, "attribute_map"):
+        attribute_map.update({{parent}}.attribute_map)
+{{/parent}}
 {{#discriminator}}
 
     discriminator_value_class_map = {
-        {{#children}}'{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}': '{{{classname}}}'{{^@last}},
-        {{/@last}}{{/children}}
+        {{#if discriminator.mapping}}
+          {{#each discriminator.mapping}}
+            '{{@key}}'.lower(): '{{this}}',
+          {{/each}}
+        {{else}}
+          {{#children}}'{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}': '{{{classname}}}'{{^@last}},
+          {{/@last}}{{/children}}
+        {{/if}}
     }
 {{/discriminator}}
 
-    def __init__(self{{#vars}}, {{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}{{/vars}}):  # noqa: E501
+    def __init__(self{{#vars}}, {{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}{{/vars}}{{#parent}}, *args, **kwargs{{/parent}}):  # noqa: E501
         """{{classname}} - a model defined in Swagger"""  # noqa: E501
 {{#vars}}{{#@first}}
 {{/@first}}
@@ -71,6 +85,9 @@ class {{classname}}({{#parent}}{{parent}}{{/parent}}{{^parent}}object{{/parent}}
             self.{{name}} = {{name}}
 {{/required}}
 {{/vars}}
+{{#parent}}
+        {{parent}}.__init__(self, *args, **kwargs)
+{{/parent}}
 
 {{#vars}}
     @property


### PR DESCRIPTION
There are several issues with the python model template that causes incorrect behavior with inherited models.

1. Subclass constructor never calls the super constructor or even takes the super constructor arguments.
2. Subclass `swagger_types` and `attribute_map` don't include parent's properties. Because of that, all parent class properties will be removed in `ApiClient.__deserialize_model`.
3. OpenAPI specification v3 supports discriminator mapping by custom names ([docs](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/)). That allows us to have custom strings in discriminator fields which then need to be mapped to class names. Currently, the model template does not render those mappings correctly.

This change fixes all the issues above.