### PR TITLE
Fix python template dir path concatenation

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
@@ -159,7 +159,7 @@ public class PythonClientCodegen extends DefaultCodegenConfig {
         super.processOpts();
         Boolean excludeTests = false;
 
-        embeddedTemplateDir = templateDir = getTemplateDir();
+        embeddedTemplateDir = templateDir + getTemplateDir();
 
         if(additionalProperties.containsKey(CodegenConstants.EXCLUDE_TESTS)) {
             excludeTests = Boolean.valueOf(additionalProperties.get(CodegenConstants.EXCLUDE_TESTS).toString());


### PR DESCRIPTION
If custom python template dir is provided it gets discarded on path concatenation, ending up with a relative path based on the current working directory.

This change fixes the issue.