### PR TITLE
Fix Python client custom template path

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
@@ -159,7 +159,10 @@ public class PythonClientCodegen extends DefaultCodegenConfig {
         super.processOpts();
         Boolean excludeTests = false;
 
-        embeddedTemplateDir = templateDir = getTemplateDir();
+        if (StringUtils.isBlank(templateDir)) {
+            String templateVersion = getTemplateVersion();
+            embeddedTemplateDir = templateDir = getTemplateDir();
+        }
 
         if(additionalProperties.containsKey(CodegenConstants.EXCLUDE_TESTS)) {
             excludeTests = Boolean.valueOf(additionalProperties.get(CodegenConstants.EXCLUDE_TESTS).toString());

--- a/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
@@ -160,7 +160,6 @@ public class PythonClientCodegen extends DefaultCodegenConfig {
         Boolean excludeTests = false;
 
         if (StringUtils.isBlank(templateDir)) {
-            String templateVersion = getTemplateVersion();
             embeddedTemplateDir = templateDir = getTemplateDir();
         }
 


### PR DESCRIPTION
If set through CLI using `--template-dir` option, the final path where the generator was looking for templates was non-existing.

This fixes the issue using the same approach as in [JavaClientCodegen](https://github.com/swagger-api/swagger-codegen-generators/blob/master/src/main/java/io/swagger/codegen/v3/generators/java/JavaClientCodegen.java#L123).