### PR TITLE
Fix recursion failure when generating examples

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/examples/ExampleGenerator.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/examples/ExampleGenerator.java
@@ -157,7 +157,10 @@ public class ExampleGenerator {
     }
 
     private Object resolveSchemaToExample(String propertyName, String mediaType, Schema schema, Set<String> processedModels) {
-//        logger.debug("Resolving example for property {}...", schema);
+        if (processedModels.contains(schema.get$ref())) {
+            return schema.getExample();
+        }
+        processedModels.add(schema.get$ref());
         if (schema.getExample() != null) {
             logger.debug("Example set in swagger spec, returning example: '{}'", schema.getExample().toString());
             return schema.getExample();
@@ -269,10 +272,10 @@ public class ExampleGenerator {
     }
 
     private Object resolveModelToExample(String name, String mediaType, Schema schema, Set<String> processedModels) {
-        if (processedModels.contains(name)) {
+        if (processedModels.contains(schema.get$ref())) {
             return schema.getExample();
         }
-        processedModels.add(name);
+        processedModels.add(schema.get$ref());
         Map<String, Object> values = new HashMap<>();
 
         logger.debug("Resolving model '{}' to example", name);

--- a/src/test/java/io/swagger/codegen/v3/generators/examples/ExampleGeneratorTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/examples/ExampleGeneratorTest.java
@@ -40,4 +40,16 @@ public class ExampleGeneratorTest {
         Assert.assertNotNull(example);
         Assert.assertTrue(example.contains("\"name\" : \"doggie\""));
     }
+
+    @Test
+    public void testExampleWithRecursiveNodes() throws Exception {
+        final Schema categorySchema = openAPI.getComponents().getSchemas().get("Category");
+        final ExampleGenerator exampleGenerator = new ExampleGenerator(openAPI);
+
+        final List<Map<String, String>> exampleList = exampleGenerator.generate(null, null, categorySchema);
+        Assert.assertEquals(exampleList.size(), 1);
+        final Map<String, String> example = exampleList.get(0);
+        Assert.assertEquals(example.get("contentType"), "application/json");
+        Assert.assertTrue(example.get("example").contains("\"name\" : \"Yinotheria\""));
+    }
 }

--- a/src/test/resources/3_0_0/petstore.yaml
+++ b/src/test/resources/3_0_0/petstore.yaml
@@ -576,6 +576,18 @@ components:
           format: int64
         name:
           type: string
+        subcategories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'
+      example:
+        - id: 100
+          name: Mammal
+          subcategories:
+            - id: 110
+              name: Yinotheria
+            - id: 120
+              name: Theriiformes
       xml:
         name: Category
     User:


### PR DESCRIPTION
This fixes an issue documented in [Issue 9546 in the swagger-codegen repo](https://github.com/swagger-api/swagger-codegen/issues/9546). The ExampleGenerator recurses infinitely when a schema object is self-referencing. 

This fixes the issue by indexing the processed models by their schema reference, and returning existing examples when they already exist. 