### PR TITLE
Fix property sanitization

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -1146,10 +1146,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         // remove everything else other than word, number and _
         // $php_variable => php_variable
         if (allowUnicodeIdentifiers) { //could be converted to a single line with ?: operator
-            name = Pattern.compile("\\W-[\\$]", Pattern.UNICODE_CHARACTER_CLASS).matcher(name).replaceAll(StringUtils.EMPTY);
+            name = Pattern.compile("[\\W&&[^$]]", Pattern.UNICODE_CHARACTER_CLASS).matcher(name).replaceAll(StringUtils.EMPTY);
         }
         else {
-            name = name.replaceAll("\\W-[\\$]", StringUtils.EMPTY);
+            name = name.replaceAll("[\\W&&[^$]]", StringUtils.EMPTY);
         }
         return name;
     }

--- a/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
@@ -95,6 +95,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(fakeJavaCodegen.toVarName("user-name"), "userName");
         Assert.assertEquals(fakeJavaCodegen.toVarName("user_name"), "userName");
         Assert.assertEquals(fakeJavaCodegen.toVarName("_user_name"), "_userName");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("@user_name"), "userName");
     }
 
     @Test

--- a/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
@@ -95,7 +95,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(fakeJavaCodegen.toVarName("user-name"), "userName");
         Assert.assertEquals(fakeJavaCodegen.toVarName("user_name"), "userName");
         Assert.assertEquals(fakeJavaCodegen.toVarName("_user_name"), "_userName");
-        Assert.assertEquals(fakeJavaCodegen.toVarName("@user_name"), "userName");
+        Assert.assertEquals(fakeJavaCodegen.toVarName(":user_name"), "userName");
     }
 
     @Test


### PR DESCRIPTION
This is an updated branch to fix the tests for https://github.com/swagger-api/swagger-codegen-generators/pull/379 because I'm not able to push directly to that branch.

That failing unit test was simply one that had become out of date due to [this PR](https://github.com/swagger-api/swagger-codegen-generators/pull/362/files) special-casing the `@` symbol. 

Closes #378 
Closes #379
Closes #563

@HugoMario for review.