### PR TITLE
java boolean field generation fixes

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -13,13 +13,7 @@ import io.swagger.codegen.v3.generators.DefaultCodegenConfig;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
-import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.IntegerSchema;
-import io.swagger.v3.oas.models.media.MapSchema;
-import io.swagger.v3.oas.models.media.NumberSchema;
-import io.swagger.v3.oas.models.media.ObjectSchema;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.apache.commons.lang3.BooleanUtils;
@@ -667,6 +661,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         } else if (propertySchema instanceof MapSchema && hasTrueAdditionalProperties(propertySchema)) {
             Schema inner = new ObjectSchema();
             return getSchemaType(propertySchema) + "<String, " + getTypeDeclaration(inner) + ">";
+        } else if (propertySchema instanceof BooleanSchema) {
+            if (propertySchema.getNullable() != null && propertySchema.getNullable()) {
+                return "Boolean";
+            } else {
+                return "boolean";
+            }
         }
         return super.getTypeDeclaration(propertySchema);
     }
@@ -913,6 +913,21 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
             codegenModel = AbstractJavaCodegen.reconcileInlineEnums(codegenModel, parentCodegenModel);
         }
         return codegenModel;
+    }
+
+    @Override
+    public CodegenProperty fromProperty(String name, Schema propertySchema) {
+        CodegenProperty codegenProperty = super.fromProperty(name, propertySchema);
+
+        if (propertySchema instanceof BooleanSchema) {
+            if (codegenProperty.datatypeWithEnum.equals("boolean")) {
+                codegenProperty.getter = toBooleanGetter(name);
+            } else {
+                codegenProperty.getter = toGetter(name);
+            }
+        }
+
+        return codegenProperty;
     }
 
     @Override

--- a/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
@@ -2,10 +2,13 @@ package io.swagger.codegen.v3.generators.java;
 
 import io.swagger.codegen.v3.CodegenArgument;
 import io.swagger.codegen.v3.CodegenConstants;
+import io.swagger.codegen.v3.CodegenProperty;
 import io.swagger.codegen.v3.CodegenType;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -104,6 +107,27 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(fakeJavaCodegen.toModelName("$name"), "Name");
         Assert.assertEquals(fakeJavaCodegen.toModelName("nam#e"), "Name");
         Assert.assertEquals(fakeJavaCodegen.toModelName("$another-fake?"), "AnotherFake");
+    }
+
+    @Test
+    public void booleanField() throws Exception {
+        String name = "myBooleanField";
+        Schema nullableSchema = new BooleanSchema().nullable(true);
+        Schema nonNullableSchema = new BooleanSchema().nullable(false);
+        Schema nullableNotSpecifiedSchema = new BooleanSchema(); // default (in Spec) is nullable: false
+
+        CodegenProperty nullableProperty = fakeJavaCodegen.fromProperty(name, nullableSchema);
+        CodegenProperty nonNullableProperty = fakeJavaCodegen.fromProperty(name, nonNullableSchema);
+        CodegenProperty nullableNotSpecifiedProperty = fakeJavaCodegen.fromProperty(name, nullableNotSpecifiedSchema);
+
+        Assert.assertEquals("getMyBooleanField", nullableProperty.getter);
+        Assert.assertEquals("Boolean", nullableProperty.datatypeWithEnum);
+
+        Assert.assertEquals("isMyBooleanField", nonNullableProperty.getter);
+        Assert.assertEquals("boolean", nonNullableProperty.datatypeWithEnum);
+
+        Assert.assertEquals("isMyBooleanField", nullableNotSpecifiedProperty.getter);
+        Assert.assertEquals("boolean", nullableNotSpecifiedProperty.datatypeWithEnum);
     }
 
     @Test


### PR DESCRIPTION
Closes #598 

This PR does the following:
- Adds a piece of logic that determines if `boolean` or `Boolean` should be used, based on whether or not the field is nullable
- Changes the getter's generation so that it is determined by the fields derived type and uses "is" for the primitive, "get" for the wrapper.
- Added a test for the possibilities: nullable, nonNullable or not specified (defaults to false, as in nonNullable)