### PR TITLE
#602 Generated code does not implement model inheritance correctly

### DIFF
--- a/src/main/resources/handlebars/JavaSpring/model.mustache
+++ b/src/main/resources/handlebars/JavaSpring/model.mustache
@@ -1,6 +1,6 @@
 package {{package}};
 
-{{^x-is-composed-model}}
+{{^isComposedModel}}
 import java.util.Objects;
 {{#imports}}import {{import}};
 {{/imports}}
@@ -21,20 +21,20 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 {{#withXml}}
 import javax.xml.bind.annotation.*;
 {{/withXml}}
-{{/x-is-composed-model}}
+{{/isComposedModel}}
 
 {{#models}}
 {{#model}}
-{{#vendorExtensions.x-is-composed-model}}
+{{#isComposedModel}}
 {{>interface}}
-{{/vendorExtensions.x-is-composed-model}}
-{{^vendorExtensions.x-is-composed-model}}
+{{/isComposedModel}}
+{{^isComposedModel}}
 {{#isEnum}}
 {{>enumOuterClass}}
 {{/isEnum}}
 {{^isEnum}}
 {{>pojo}}
 {{/isEnum}}
-{{/vendorExtensions.x-is-composed-model}}
+{{/isComposedModel}}
 {{/model}}
 {{/models}}

--- a/src/main/resources/handlebars/JavaSpring/typeInfoAnnotation.mustache
+++ b/src/main/resources/handlebars/JavaSpring/typeInfoAnnotation.mustache
@@ -1,7 +1,14 @@
 {{#jackson}}
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{discriminator.propertyName}}", visible = true )
 @JsonSubTypes({
-  {{#children}}
-  @JsonSubTypes.Type(value = {{classname}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),
-  {{/children}}
-}){{/jackson}}
+  {{#if discriminator.mapping}}
+    {{#each discriminator.mapping}}
+        @JsonSubTypes.Type(value = {{this}}.class, name = "{{@key}}"),
+    {{/each}}
+  {{else}}
+    {{#children}}
+        @JsonSubTypes.Type(value = {{classname}}.class, name = "{{name}}"),
+    {{/children}}
+  {{/if}}
+})
+{{/jackson}}


### PR DESCRIPTION
Fix handling of composed models and adjustments to model.mustache and typeInfoAnnotation.mustache templates to correctly generate models with inheritance structure.

The problem was due to three different reasons:
- The SpringCodegen source code was missing the handling of composed models.
- The model.mustache template was referring to a deprecated variable concerning composed models.
- The typeInfoAnnotation.mustache template was missing the handling of discriminator mapping.