### PR TITLE
Fixing filename concatenation issue in generation [Windows/Java JAX-RS]

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaJAXRSServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaJAXRSServerCodegen.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.models.PathItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -224,12 +225,12 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         String result = super.apiFilename(templateName, tag);
 
         if ( templateName.endsWith("Impl.mustache") ) {
-            int ix = result.lastIndexOf('/');
-            result = result.substring(0, ix) + "/impl" + result.substring(ix, result.length() - 5) + "ServiceImpl.java";
+            int ix = result.lastIndexOf(File.separatorChar);
+            result = result.substring(0, ix) + File.separator + "impl" + result.substring(ix, result.length() - 5) + "ServiceImpl.java";
             result = result.replace(apiFileFolder(), implFileFolder(implFolder));
         } else if ( templateName.endsWith("Factory.mustache") ) {
-            int ix = result.lastIndexOf('/');
-            result = result.substring(0, ix) + "/factories" + result.substring(ix, result.length() - 5) + "ServiceFactory.java";
+            int ix = result.lastIndexOf(File.separatorChar);
+            result = result.substring(0, ix) + File.separator + "factories" + result.substring(ix, result.length() - 5) + "ServiceFactory.java";
             result = result.replace(apiFileFolder(), implFileFolder(implFolder));
         } else if ( templateName.endsWith("Service.mustache") ) {
             int ix = result.lastIndexOf('.');

--- a/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaJAXRSServerCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaJAXRSServerCodegenTest.java
@@ -66,6 +66,30 @@ public class AbstractJavaJAXRSServerCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.iiii.invoker");
     }
 
+    @Test
+    public void testApiFilenameImplTemplate() {
+        final AbstractJavaJAXRSServerCodegen codegen = new P_AbstractJavaJAXRSServerCodegen();
+        codegen.apiTemplateFiles().put("Impl.mustache", ".java");
+
+        final String actual = codegen.apiFilename("Impl.mustache", "test");
+        // Many apis still concatenate with a hardcoded "/", so the test uses forward slashes where appropriate
+        final String expectedFilename = codegen.outputFolder() + "/" + codegen.implFolder + "/" + codegen.apiPackage().replace('.', '/') + "\\impl\\TestApiServiceImpl.java";
+
+        Assert.assertEquals(actual, expectedFilename);
+    }
+
+    @Test
+    public void testApiFilenameFactoryTemplate() {
+        final AbstractJavaJAXRSServerCodegen codegen = new P_AbstractJavaJAXRSServerCodegen();
+        codegen.apiTemplateFiles().put("Factory.mustache", ".java");
+
+        final String actual = codegen.apiFilename("Factory.mustache", "test");
+        // Many apis still concatenate with a hardcoded "/", so the test uses forward slashes where necessary
+        final String expectedFilename = codegen.outputFolder() + "/" + codegen.implFolder + "/" + codegen.apiPackage().replace('.', '/') + "\\factories\\TestApiServiceFactory.java";
+
+        Assert.assertEquals(actual, expectedFilename);
+    }
+
     private static class P_AbstractJavaJAXRSServerCodegen extends AbstractJavaJAXRSServerCodegen {
         @Override
         public String getArgumentsLocation() {


### PR DESCRIPTION
Fixing an issue on windows caused by inconsistent use of the OS file separator character and hardcoded `/` in the Java JAX-RS generator. Added tests for affected workflows as well.

resolves #626 