### PR TITLE
Fixing some scala akka server http issues

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegen.java
@@ -176,10 +176,10 @@ public class AkkaHttpServerCodegen extends AbstractScalaCodegen  {
             if(path.startsWith("{") && path.endsWith("}")) {
                 String parameterName = path.substring(1, path.length()-1);
                 for(CodegenParameter pathParam: codegenOperation.pathParams){
-                    if(pathParam.paramName.equals(parameterName)) {
+                    if(pathParam.baseName.equals(parameterName)) {
                         String matcher = pathTypeToMatcher.get(pathParam.dataType);
                         if(matcher == null) {
-                            LOGGER.warn("The path parameter " + pathParam.paramName +
+                            LOGGER.warn("The path parameter " + pathParam.baseName +
                                     " with the datatype " + pathParam.dataType +
                                     " could not be translated to a corresponding path matcher of akka http" +
                                     " and therefore has been translated to string.");

--- a/src/main/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegen.java
@@ -227,6 +227,9 @@ public class AkkaHttpServerCodegen extends AbstractScalaCodegen  {
             if(!primitiveParamTypes.contains(parameter.dataType)){
                 parameterCopy.dataType = FALLBACK_DATA_TYPE;
             }
+            if (!parameterCopy.required && parameterCopy.dataType.equals("String") && parameterCopy.defaultValue != null) {
+                parameterCopy.defaultValue = String.format("\"%s\"", parameterCopy.defaultValue);
+            }
             queryParamsWithSupportedType.add(parameterCopy);
         }
         codegenOperation.getVendorExtensions().put(QUERY_PARAMS_WITH_SUPPORTED_TYPE, queryParamsWithSupportedType);
@@ -253,6 +256,11 @@ public class AkkaHttpServerCodegen extends AbstractScalaCodegen  {
             } else if(parameter.getIsCookieParam()){
                 parameterCopy.dataType = COOKIE_DATA_TYPE;
             }
+
+            if (!parameterCopy.required && parameterCopy.dataType.equals("String") && parameterCopy.defaultValue != null) {
+                parameterCopy.defaultValue = String.format("\"%s\"", parameterCopy.defaultValue);
+            }
+
             allParamsWithSupportedType.add(parameterCopy);
         }
         codegenOperation.getVendorExtensions().put(PARAMS_WITH_SUPPORTED_TYPE, allParamsWithSupportedType);

--- a/src/main/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegen.java
@@ -78,7 +78,8 @@ public class AkkaHttpServerCodegen extends AbstractScalaCodegen  {
         Boolean hasComplexTypes = Boolean.FALSE;
         Boolean hasCookieParams = Boolean.FALSE;
         Set<String> complexRequestTypes = new HashSet<>();
-        List<CodegenResponse> complexReturnTypes = new ArrayList<>();
+        Set<String> complexResponseDataTypes = new HashSet<>();
+        Set<CodegenResponse> complexReturnTypes = new HashSet<>();
         for (CodegenOperation op : operationList) {
             List<CodegenResponse> complexOperationReturnTypes = new ArrayList<>();
             for(CodegenParameter parameter : op.allParams) {
@@ -94,8 +95,11 @@ public class AkkaHttpServerCodegen extends AbstractScalaCodegen  {
             }
             for(CodegenResponse response : op.responses) {
                 if(!response.getIsPrimitiveType()){
-                    hasComplexTypes = Boolean.TRUE;
-                    complexReturnTypes.add(response);
+                    if (!complexResponseDataTypes.contains(response.dataType)) {
+                        hasComplexTypes = Boolean.TRUE;
+                        complexResponseDataTypes.add(response.dataType);
+                        complexReturnTypes.add(response);
+                    }
                     complexOperationReturnTypes.add(response);
                 }
             }

--- a/src/main/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegen.java
@@ -40,7 +40,7 @@ public class AkkaHttpServerCodegen extends AbstractScalaCodegen  {
         additionalProperties.put(CodegenConstants.GROUP_ID, groupId);
         additionalProperties.put(CodegenConstants.ARTIFACT_ID, artifactId);
         additionalProperties.put(CodegenConstants.ARTIFACT_VERSION, artifactVersion);
-        additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
+
         apiPackage = "io.swagger.server.api";
         modelPackage = "io.swagger.server.model";
 
@@ -48,17 +48,23 @@ public class AkkaHttpServerCodegen extends AbstractScalaCodegen  {
         modelTemplateFiles.put("model.mustache", ".scala");
 
         supportingFiles.add(new SupportingFile("build.sbt.mustache", "", "build.sbt"));
-        supportingFiles.add(new SupportingFile("controller.mustache",
-                (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "Controller.scala"));
-        supportingFiles.add(new SupportingFile("helper.mustache",
-                (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "AkkaHttpHelper.scala"));
-
     }
 
     @Override
     public void processOpts() {
         super.processOpts();
+        if (additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
+            invokerPackage = (String) additionalProperties.get(CodegenConstants.INVOKER_PACKAGE);
+        } else {
+            additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
+        }
+
         embeddedTemplateDir = templateDir = getTemplateDir();
+
+        supportingFiles.add(new SupportingFile("controller.mustache",
+            (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "Controller.scala"));
+        supportingFiles.add(new SupportingFile("helper.mustache",
+            (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "AkkaHttpHelper.scala"));
     }
 
     @Override

--- a/src/main/resources/mustache/scala/akka-http-server/api.mustache
+++ b/src/main/resources/mustache/scala/akka-http-server/api.mustache
@@ -23,7 +23,7 @@ class {{classname}}(
   {{#operation}}
     path({{#vendorExtensions.paths}}{{#isText}}"{{/isText}}{{value}}{{#isText}}"{{/isText}}{{#hasMore}} / {{/hasMore}}{{/vendorExtensions.paths}}) { {{^pathParams.isEmpty}}({{#pathParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/pathParams}}) => {{/pathParams.isEmpty}}
       {{vendorExtensions.lowercaseHttpMethod}} {
-        {{^queryParams.isEmpty}}parameters({{#vendorExtensions.queryParamsWithSupportedType}}"{{baseName}}".as[{{dataType}}]{{^required}}.?{{/required}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.queryParamsWithSupportedType}}) { ({{#queryParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/queryParams}}) =>{{/queryParams.isEmpty}}
+        {{^queryParams.isEmpty}}parameters({{#vendorExtensions.queryParamsWithSupportedType}}"{{baseName}}".as[{{dataType}}]{{^required}}.?({{{defaultValue}}}){{/required}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.queryParamsWithSupportedType}}) { ({{#queryParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/queryParams}}) =>{{/queryParams.isEmpty}}
           {{#headerParams}}{{#required}}headerValueByName{{/required}}{{^required}}optionalHeaderValueByName{{/required}}("{{baseName}}") { {{paramName}} => {{/headerParams}}
             {{^formParams.isEmpty}}formFields({{#formParams}}"{{baseName}}".as[{{#isPrimitiveType}}{{dataType}}{{/isPrimitiveType}}{{^isPrimitiveType}}String{{/isPrimitiveType}}]{{^required}}.?{{/required}}{{#hasMore}}, {{/hasMore}}{{/formParams}}) { ({{#formParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/formParams}}) =>{{/formParams.isEmpty}}
               {{#allParams}}{{#isCookieParam}}{{#required}}cookie({{/required}}{{^required}}optionalCookie({{/required}}"{{baseName}}"){ {{paramName}} => {{/isCookieParam}}{{/allParams}}
@@ -49,7 +49,7 @@ trait {{classname}}Service {
 {{#responses}}   * {{#code}}Code: {{.}}{{/code}}{{#message}}, Message: {{.}}{{/message}}{{#dataType}}, DataType: {{.}}{{/dataType}}
    {{/responses}}
    */
-  def {{operationId}}({{#vendorExtensions.paramsWithSupportedType}}{{paramName}}: {{^required}}{{^isBodyParam}}Option[{{/isBodyParam}}{{/required}}{{dataType}}{{^required}}{{^isBodyParam}}]{{/isBodyParam}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.paramsWithSupportedType}}){{^vendorExtensions.complexReturnTypes.isEmpty}}
+  def {{operationId}}({{#vendorExtensions.paramsWithSupportedType}}{{paramName}}: {{dataType}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.paramsWithSupportedType}}){{^vendorExtensions.complexReturnTypes.isEmpty}}
       (implicit {{#vendorExtensions.complexReturnTypes}}toEntityMarshaller{{baseType}}{{containerType}}: ToEntityMarshaller[{{dataType}}]{{^-last}}, {{/-last}}{{/vendorExtensions.complexReturnTypes}}){{/vendorExtensions.complexReturnTypes.isEmpty}}: Route
 
 {{/operation}}

--- a/src/test/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegenTest.java
@@ -126,13 +126,13 @@ public class AkkaHttpServerCodegenTest {
         Assert.assertEquals((LinkedList<TextOrMatcher>) codegenOperation.getVendorExtensions().get(AkkaHttpServerCodegen.PATHS), expectedPaths);
 
         CodegenParameter petId = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
-        petId.paramName = "petId";
+        petId.baseName = "petId";
         petId.dataType = "Long";
         CodegenParameter petName = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
-        petName.paramName = "petName";
+        petName.baseName = "petName";
         petName.dataType = "String";
         CodegenParameter unknownMatcher = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
-        unknownMatcher.paramName = "unknownMatcher";
+        unknownMatcher.baseName = "unknownMatcher";
         unknownMatcher.dataType = "List[String]";
         codegenOperation.path = "/pet/{petId}/name/{petName}/{unknownMatcher}";
         codegenOperation.pathParams.add(petId);

--- a/src/test/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/scala/AkkaHttpServerCodegenTest.java
@@ -87,7 +87,7 @@ public class AkkaHttpServerCodegenTest {
 
         Assert.assertEquals(result.get("hasComplexTypes"), Boolean.TRUE);
         Assert.assertEquals(result.get("complexRequestTypes"), new HashSet<String>(){{addAll(Arrays.asList("Pet","User"));}});
-        Assert.assertEquals(result.get("complexReturnTypes"), new LinkedList<CodegenResponse>(){{addAll(Arrays.asList(response1, response2, response3));}});
+        Assert.assertEquals(result.get("complexReturnTypes"), new HashSet<CodegenResponse>(){{addAll(Arrays.asList(response1, response3));}});
         Assert.assertEquals(codegenOperation1.getVendorExtensions().get("complexReturnTypes"), new LinkedList<CodegenResponse>(){{add(response1);}});
         Assert.assertEquals(codegenOperation2.getVendorExtensions().get("complexReturnTypes"), new LinkedList<CodegenResponse>(){{addAll(Arrays.asList(response1, response3));}});
     }


### PR DESCRIPTION
This PR does the following:
- the --invoker-package additional property isn't overwritten anymore.
- it fixes a bug where path parameter type were not correctly computed, resulting in a bad file generation. The problem occured when parameters were defined by reference instead of directly in the operation.
- The default value of optional query parameters is now used. Thus, the signature of generated operation function doesn't take optional parameters anymore, as the default value is used.
- it fixes a problem where multiple occurences of the same Unmarshaller were generated. 