### PR TITLE
Update generators for 3.0.0

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -2112,6 +2112,9 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
                         // todo: this segment is only to support the "older" template design. it should be removed once all templates are updated with the new {{#contents}} tag.
                         bodyParams.add(bodyParam.copy());
                         allParams.add(bodyParam);
+                        if (body.getRequired() != null && body.getRequired()) {
+                            requiredParams.add(bodyParam.copy());
+                        }
                     } else {
                         boolean alreadyAdded = false;
                         for (Schema usedSchema : foundSchemas) {

--- a/src/main/resources/handlebars/Java/api.mustache
+++ b/src/main/resources/handlebars/Java/api.mustache
@@ -41,6 +41,79 @@ public class {{classname}} {
 
   {{#operation}}
   {{#contents}}
+  {{#hasOptionalParams}}
+  public static class {{operationIdCamelCase}}Optionals {
+    {{#allParams}}{{^required}}
+    public {{{dataType}}} {{paramName}}() {
+      return this.{{paramName}};
+    }
+
+    public {{operationIdCamelCase}}Optionals {{paramName}}({{{dataType}}} {{paramName}}) {
+      this.{{paramName}} = {{paramName}};
+      return this;
+    }
+
+    private {{{dataType}}} {{paramName}} = null;
+    {{/required}}{{/allParams}}
+  }
+  {{/hasOptionalParams}}
+
+  {{#hasOptionalParams}}
+  /**
+   * {{summary}}
+   * {{notes}}
+   {{#requiredParams}}
+   * @param {{paramName}} {{description}} (required)
+   {{/requiredParams}}
+   {{#returnType}}
+   * @return {{returnType}}
+   {{/returnType}}
+   * @throws ApiException if fails to make API call
+   {{#isDeprecated}}
+   * @deprecated
+   {{/isDeprecated}}
+   {{#externalDocs}}
+   * {{description}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
+   {{/externalDocs}}
+   */
+  {{#isDeprecated}}
+  @Deprecated
+  {{/isDeprecated}}
+  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#requiredParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/requiredParams}}) throws ApiException {
+    {{#returnType}}return {{/returnType}}{{operationId}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}null{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+  }
+
+  /**
+   * {{summary}}
+   * {{notes}}
+   {{#requiredParams}}
+   * @param {{paramName}} {{description}} (required)
+   {{/requiredParams}}
+   * @param optionals An object containing the optional parameters for this API call.
+   {{#returnType}}
+   * @return {{returnType}}
+   {{/returnType}}
+   * @throws ApiException if fails to make API call
+   {{#isDeprecated}}
+   * @deprecated
+   {{/isDeprecated}}
+   {{#externalDocs}}
+   * {{description}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
+   {{/externalDocs}}
+   */
+  {{#isDeprecated}}
+  @Deprecated
+  {{/isDeprecated}}
+  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}Opts({{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}{{operationIdCamelCase}}Optionals optionals) throws ApiException {
+    if (optionals == null) {
+      optionals = new {{operationIdCamelCase}}Optionals();
+    }
+    {{#returnType}}return {{/returnType}}{{operationId}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}optionals.{{paramName}}(){{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+  }
+  {{/hasOptionalParams}}
+
   /**
    * {{summary}}
    * {{notes}}

--- a/src/main/resources/handlebars/Java/libraries/jersey2/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/jersey2/api.mustache
@@ -40,6 +40,79 @@ public class {{classname}} {
 
   {{#operation}}
   {{#contents}}
+  {{#hasOptionalParams}}
+  public static class {{operationIdCamelCase}}Optionals {
+    {{#allParams}}{{^required}}
+    public {{{dataType}}} {{paramName}}() {
+      return this.{{paramName}};
+    }
+
+    public {{operationIdCamelCase}}Optionals {{paramName}}({{{dataType}}} {{paramName}}) {
+      this.{{paramName}} = {{paramName}};
+      return this;
+    }
+
+    private {{{dataType}}} {{paramName}} = null;
+    {{/required}}{{/allParams}}
+  }
+  {{/hasOptionalParams}}
+
+  {{#hasOptionalParams}}
+  /**
+   * {{summary}}
+   * {{notes}}
+   {{#requiredParams}}
+   * @param {{paramName}} {{description}} (required)
+   {{/requiredParams}}
+   {{#returnType}}
+   * @return {{returnType}}
+   {{/returnType}}
+   * @throws ApiException if fails to make API call
+   {{#isDeprecated}}
+   * @deprecated
+   {{/isDeprecated}}
+   {{#externalDocs}}
+   * {{description}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
+   {{/externalDocs}}
+   */
+  {{#isDeprecated}}
+  @Deprecated
+  {{/isDeprecated}}
+  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#requiredParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/requiredParams}}) throws ApiException {
+    {{#returnType}}return {{/returnType}}{{operationId}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}null{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+  }
+
+  /**
+   * {{summary}}
+   * {{notes}}
+   {{#requiredParams}}
+   * @param {{paramName}} {{description}} (required)
+   {{/requiredParams}}
+   * @param optionals An object containing the optional parameters for this API call.
+   {{#returnType}}
+   * @return {{returnType}}
+   {{/returnType}}
+   * @throws ApiException if fails to make API call
+   {{#isDeprecated}}
+   * @deprecated
+   {{/isDeprecated}}
+   {{#externalDocs}}
+   * {{description}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
+   {{/externalDocs}}
+   */
+  {{#isDeprecated}}
+  @Deprecated
+  {{/isDeprecated}}
+  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}Opts({{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}{{operationIdCamelCase}}Optionals optionals) throws ApiException {
+    if (optionals == null) {
+      optionals = new {{operationIdCamelCase}}Optionals();
+    }
+    {{#returnType}}return {{/returnType}}{{operationId}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}optionals.{{paramName}}(){{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+  }
+  {{/hasOptionalParams}}
+
   /**
    * {{summary}}
    * {{notes}}

--- a/src/main/resources/handlebars/Java/libraries/okhttp-gson/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/okhttp-gson/api.mustache
@@ -64,6 +64,73 @@ public class {{classname}} {
 
     {{#operation}}
     {{#contents}}
+    {{#hasOptionalParams}}
+    public static class {{operationIdCamelCase}}Optionals {
+      {{#allParams}}{{^required}}
+        public {{{dataType}}} {{paramName}}() {
+            return this.{{paramName}};
+        }
+
+        public {{operationIdCamelCase}}Optionals {{paramName}}({{{dataType}}} {{paramName}}) {
+            this.{{paramName}} = {{paramName}};
+            return this;
+        }
+
+        private {{{dataType}}} {{paramName}} = null;
+        {{/required}}{{/allParams}}
+    }
+    {{/hasOptionalParams}}
+
+    {{#hasOptionalParams}}
+    /**
+     * Build call for {{operationId}}{{#requiredParams}}
+     * @param {{paramName}} {{description}} (required){{/requiredParams}}
+     * @param progressListener Progress listener
+     * @param progressRequestListener Progress request listener
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public com.squareup.okhttp.Call {{operationId}}Call({{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+        return {{operationId}}Call({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}null{{/required}}, {{/allParams}}progressListener, progressRequestListener);
+    }
+
+    /**
+     * Build call for {{operationId}}{{#requiredParams}}
+     * @param {{paramName}} {{description}} (required){{/requiredParams}}
+     * @param optionals An object containing the optional parameters for this API call.
+     * @param progressListener Progress listener
+     * @param progressRequestListener Progress request listener
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public com.squareup.okhttp.Call {{operationId}}OptsCall({{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}{{operationIdCamelCase}}Optionals optionals, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+        if (optionals == null) {
+            optionals = new {{operationIdCamelCase}}Optionals();
+        }
+        return {{operationId}}Call({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}optionals.{{paramName}}(){{/required}}, {{/allParams}}progressListener, progressRequestListener);
+    }
+    {{/hasOptionalParams}}
+
     /**
      * Build call for {{operationId}}{{#parameters}}
      * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/parameters}}
@@ -78,7 +145,7 @@ public class {{classname}} {
      */
     public com.squareup.okhttp.Call {{operationId}}Call({{#parameters}}{{{dataType}}} {{paramName}}, {{/parameters}}final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object {{localVariablePrefix}}localVarPostBody = {{^isForm}}{{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}{{/isForm}}{{#isForm}}null{{/isForm}};
-        
+
         // create path and map variables
         String {{localVariablePrefix}}localVarPath = "{{{path}}}"{{#pathParams}}
             .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
@@ -127,7 +194,7 @@ public class {{classname}} {
         String[] {{localVariablePrefix}}localVarAuthNames = new String[] { {{#authMethods}}"{{name}}"{{#has this 'more'}}, {{/has}}{{/authMethods}} };
         return {{localVariablePrefix}}apiClient.buildCall({{localVariablePrefix}}localVarPath, "{{httpMethod}}", {{localVariablePrefix}}localVarQueryParams, {{localVariablePrefix}}localVarCollectionQueryParams, {{localVariablePrefix}}localVarPostBody, {{localVariablePrefix}}localVarHeaderParams, {{localVariablePrefix}}localVarFormParams, {{localVariablePrefix}}localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call {{operationId}}ValidateBeforeCall({{#parameters}}{{{dataType}}} {{paramName}}, {{/parameters}}final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         {{^performBeanValidation}}
@@ -137,7 +204,7 @@ public class {{classname}} {
             throw new ApiException("Missing the required parameter '{{paramName}}' when calling {{operationId}}(Async)");
         }
         {{/required}}{{/parameters}}
-        
+
         com.squareup.okhttp.Call {{localVariablePrefix}}call = {{operationId}}Call({{#parameters}}{{paramName}}, {{/parameters}}progressListener, progressRequestListener);
         return {{localVariablePrefix}}call;
 
@@ -155,7 +222,7 @@ public class {{classname}} {
             if (violations.size() == 0) {
                 com.squareup.okhttp.Call {{localVariablePrefix}}call = {{operationId}}Call({{#parameters}}{{paramName}}, {{/parameters}}progressListener, progressRequestListener);
                 return {{localVariablePrefix}}call;
-            
+
             } else {
                 throw new BeanValidationException((Set) violations);
             }
@@ -166,13 +233,61 @@ public class {{classname}} {
             e.printStackTrace();
             throw new ApiException(e.getMessage());
         }
-            
+
         {{/performBeanValidation}}
-        
-        
-        
-        
+
+
+
+
     }
+
+    {{#hasOptionalParams}}
+    /**
+     * {{summary}}
+     * {{notes}}{{#requiredParams}}
+     * @param {{paramName}} {{description}} (required){{/requiredParams}}{{#returnType}}
+     * @return {{returnType}}{{/returnType}}
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#requiredParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/requiredParams}}) throws ApiException {
+        {{#returnType}}return {{/returnType}}{{operationId}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}null{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+    }
+
+    /**
+     * {{summary}}
+     * {{notes}}{{#requiredParams}}
+     * @param {{paramName}} {{description}} (required){{/requiredParams}}
+     * @param optionals An object containing the optional parameters for this API call.{{#returnType}}
+     * @return {{returnType}}{{/returnType}}
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}Opts({{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}{{operationIdCamelCase}}Optionals optionals) throws ApiException {
+        if (optionals == null) {
+            optionals = new {{operationIdCamelCase}}Optionals();
+        }
+        {{#returnType}}return {{/returnType}}{{operationId}}({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}optionals.{{paramName}}(){{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+    }
+    {{/hasOptionalParams}}
 
     /**
      * {{summary}}
@@ -190,6 +305,54 @@ public class {{classname}} {
         return {{localVariablePrefix}}resp.getData();{{/returnType}}
     }
 
+    {{#hasOptionalParams}}
+    /**
+     * {{summary}}
+     * {{notes}}{{#requiredParams}}
+     * @param {{paramName}} {{description}} (required){{/requiredParams}}{{#returnType}}
+     * @return {{returnType}}{{/returnType}}
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#requiredParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/requiredParams}}) throws ApiException {
+        return {{operationId}}WithHttpInfo({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}null{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+    }
+
+    /**
+     * {{summary}}
+     * {{notes}}{{#requiredParams}}
+     * @param {{paramName}} {{description}} (required){{/requiredParams}}
+     * @param optionals An object containing the optional parameters for this API call.{{#returnType}}
+     * @return {{returnType}}{{/returnType}}
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}OptsWithHttpInfo({{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}{{operationIdCamelCase}}Optionals optionals) throws ApiException {
+        if (optionals == null) {
+            optionals = new {{operationIdCamelCase}}Optionals();
+        }
+        return {{operationId}}WithHttpInfo({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}optionals.{{paramName}}(){{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+    }
+    {{/hasOptionalParams}}
+
     /**
      * {{summary}}
      * {{notes}}{{#parameters}}
@@ -206,6 +369,56 @@ public class {{classname}} {
         {{#returnType}}Type {{localVariablePrefix}}localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
         return {{localVariablePrefix}}apiClient.execute({{localVariablePrefix}}call, {{localVariablePrefix}}localVarReturnType);{{/returnType}}{{^returnType}}return {{localVariablePrefix}}apiClient.execute({{localVariablePrefix}}call);{{/returnType}}
     }
+
+    {{#hasOptionalParams}}
+    /**
+     * {{summary}} (asynchronously)
+     * {{notes}}{{#requiredParams}}
+     * @param {{paramName}} {{description}} (required){{/requiredParams}}
+     * @param callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public com.squareup.okhttp.Call {{operationId}}Async({{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}final ApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{localVariablePrefix}}callback) throws ApiException {
+        return {{operationId}}Async({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}null{{/required}}, {{/allParams}}{{localVariablePrefix}}callback);
+    }
+
+    /**
+     * {{summary}} (asynchronously)
+     * {{notes}}{{#requiredParams}}
+     * @param {{paramName}} {{description}} (required){{/requiredParams}}
+     * @param optionals An object containing the optional parameters for this API call.
+     * @param callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
+        {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public com.squareup.okhttp.Call {{operationId}}OptsAsync({{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}{{operationIdCamelCase}}Optionals optionals, final ApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{localVariablePrefix}}callback) throws ApiException {
+        if (optionals == null) {
+            optionals = new {{operationIdCamelCase}}Optionals();
+        }
+        return {{operationId}}Async({{#allParams}}{{#required}}{{paramName}}{{/required}}{{^required}}optionals.{{paramName}}(){{/required}}, {{/allParams}}{{localVariablePrefix}}callback);
+    }
+    {{/hasOptionalParams}}
 
     /**
      * {{summary}} (asynchronously)


### PR DESCRIPTION
Implemented [#10176 (from the swagger-codegen repo)](https://github.com/swagger-api/swagger-codegen/issues/10176) for jersey1, jersey2, and okhttp-gson. Each API call now has up to two additional methods:
* one containing only required parameters
* one containing required parameters + optional parameters, the latter in a builder-style format