### PR TITLE
fix for invalid model name in html2 genetator

### DIFF
--- a/src/main/resources/handlebars/htmlDocs2/index.mustache
+++ b/src/main/resources/handlebars/htmlDocs2/index.mustache
@@ -115,10 +115,10 @@
         {{#models}}
         {{#model}}
             {{#isComposedModel}}
-            defs.{{name}} = {};
+            defs["{{name}}"] = {};
             {{/isComposedModel}}
             {{^isComposedModel}}
-            defs.{{name}} = {{{modelJson}}};
+            defs["{{name}}"] = {{{modelJson}}};
             {{/isComposedModel}}
         {{/model}}
     {{/models}}


### PR DESCRIPTION
fix for invalid model name in html2 genetator