### PR TITLE
added option to throw error instead return null for unknown enum values

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -52,6 +52,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
     public static final String JAVA8_MODE = "java8";
     public static final String WITH_XML = "withXml";
     public static final String SUPPORT_JAVA6 = "supportJava6";
+    public static final String ERROR_ON_UNKNOWN_ENUM = "errorOnUnknownEnum";
 
     protected String dateLibrary = "threetenbp";
     protected boolean java8Mode = false;
@@ -331,6 +332,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
 
         if (additionalProperties.containsKey(FULL_JAVA_UTIL)) {
             this.setFullJavaUtil(Boolean.valueOf(additionalProperties.get(FULL_JAVA_UTIL).toString()));
+        }
+
+        if (additionalProperties.containsKey(ERROR_ON_UNKNOWN_ENUM)) {
+            boolean errorOnUnknownEnum = Boolean.parseBoolean(additionalProperties.get(ERROR_ON_UNKNOWN_ENUM).toString());
+            additionalProperties.put(ERROR_ON_UNKNOWN_ENUM, errorOnUnknownEnum);
         }
 
         if (this instanceof NotNullAnnotationFeatures) {

--- a/src/main/resources/handlebars/Java/modelEnum.mustache
+++ b/src/main/resources/handlebars/Java/modelEnum.mustache
@@ -50,7 +50,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
   }
 {{#if gson}}
 

--- a/src/main/resources/handlebars/Java/modelInnerEnum.mustache
+++ b/src/main/resources/handlebars/Java/modelInnerEnum.mustache
@@ -34,7 +34,7 @@
           return b;
         }
       }
-      return null;
+      {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
     }
     {{#gson}}
     public static class Adapter extends TypeAdapter<{{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}> {

--- a/src/main/resources/handlebars/JavaInflector/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaInflector/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
     }
   }

--- a/src/main/resources/handlebars/JavaInflector/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaInflector/enumOuterClass.mustache
@@ -42,6 +42,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
   }
 }

--- a/src/main/resources/handlebars/JavaJaxRS/cxf-cdi/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/cxf-cdi/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{datatypeWithEnum}} {
                 return b;
             }
         }
-        return null;
+        {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
     }
 }

--- a/src/main/resources/handlebars/JavaJaxRS/cxf/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/cxf/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{datatypeWithEnum}} {
                 return b;
             }
         }
-        return null;
+        {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
     }
 }

--- a/src/main/resources/handlebars/JavaJaxRS/cxf/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/cxf/enumOuterClass.mustache
@@ -63,7 +63,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
   }
   
 }

--- a/src/main/resources/handlebars/JavaJaxRS/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
     }
   }

--- a/src/main/resources/handlebars/JavaJaxRS/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
   }
 }

--- a/src/main/resources/handlebars/JavaJaxRS/spec/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/spec/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{datatypeWithEnum}} {
                 return b;
             }
         }
-        return null;
+        {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
     }
 }

--- a/src/main/resources/handlebars/JavaJaxRS/spec/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/spec/enumOuterClass.mustache
@@ -38,6 +38,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
   }
 }

--- a/src/main/resources/handlebars/JavaMicronaut/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaMicronaut/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
     }
   }

--- a/src/main/resources/handlebars/JavaMicronaut/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaMicronaut/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
   }
 }

--- a/src/main/resources/handlebars/JavaSpring/enumClass.mustache
+++ b/src/main/resources/handlebars/JavaSpring/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
     }
   }

--- a/src/main/resources/handlebars/JavaSpring/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaSpring/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{^errorOnUnknownEnum}}return null;{{/errorOnUnknownEnum}}{{#errorOnUnknownEnum}}throw new IllegalArgumentException("Unexpected value '" + text + "' for '{{{classname}}}' enum.");{{/errorOnUnknownEnum}}
   }
 }


### PR DESCRIPTION
applied changes from [swagger-codegen#10356](https://github.com/swagger-api/swagger-codegen/pull/10356)