### PR TITLE
[JAVA] Refactor so "useTags" feature is available for all AbstractJavaJAXRSServerCodegen implementations

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/JavaJAXRSSpecServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/JavaJAXRSSpecServerCodegen.java
@@ -121,35 +121,6 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     }
 
     @Override
-    public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
-        String basePath = resourcePath;
-        if (basePath.startsWith("/")) {
-            basePath = basePath.substring(1);
-        }
-        int pos = basePath.indexOf("/");
-        if (pos > 0) {
-            basePath = basePath.substring(0, pos);
-        }
-
-        if (basePath == "") {
-            basePath = "default";
-        }
-        else {
-            if (co.path.startsWith("/" + basePath)) {
-                co.path = co.path.substring(("/" + basePath).length());
-            }
-            co.subresourceOperation = !co.path.isEmpty();
-        }
-        List<CodegenOperation> opList = operations.get(basePath);
-        if (opList == null) {
-            opList = new ArrayList<CodegenOperation>();
-            operations.put(basePath, opList);
-        }
-        opList.add(co);
-        co.baseName = basePath;
-    }
-
-    @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
         super.postProcessModelProperty(model, property);
         if (useOas2) {

--- a/src/main/java/io/swagger/codegen/v3/generators/java/JavaJerseyServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/JavaJerseyServerCodegen.java
@@ -3,14 +3,11 @@ package io.swagger.codegen.v3.generators.java;
 import io.swagger.codegen.v3.CliOption;
 import io.swagger.codegen.v3.CodegenConstants;
 import io.swagger.codegen.v3.CodegenModel;
-import io.swagger.codegen.v3.CodegenOperation;
 import io.swagger.codegen.v3.CodegenProperty;
 import io.swagger.codegen.v3.SupportingFile;
-import io.swagger.v3.oas.models.Operation;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/io/swagger/codegen/v3/generators/java/JavaJAXRSSpecServerCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/JavaJAXRSSpecServerCodegenTest.java
@@ -1,0 +1,204 @@
+package io.swagger.codegen.v3.generators.java;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.rules.TemporaryFolder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.swagger.codegen.v3.ClientOptInput;
+import io.swagger.codegen.v3.DefaultGenerator;
+import io.swagger.codegen.v3.config.CodegenConfigurator;
+import io.swagger.codegen.v3.generators.AbstractCodegenTest;
+
+public class JavaJAXRSSpecServerCodegenTest extends AbstractCodegenTest {
+
+    /**
+     * Base path that API files will be generated in to. 
+     */
+    private static final String API_PATH = "/src/gen/java/io/swagger/api/";
+
+    private final TemporaryFolder folder = new TemporaryFolder();
+    private File output = null;
+
+    /**
+     * Generate code for this generator.
+     * 
+     * @param additionalProperties map containing additional properties which should
+     *                             be passed to the generator.
+     * @throws IOException if an error occurs while generating code.
+     */
+    private void generateCode(Map<String, Object> additionalProperties) throws IOException {
+
+        this.folder.create();
+        output = this.folder.getRoot();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setLang("jaxrs-spec")
+                .setInputSpecURL("src/test/resources/3_0_0/composed_schemas.yaml")
+                .setOutputDir(output.getAbsolutePath())
+                .setAdditionalProperties(additionalProperties);
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        new DefaultGenerator().opts(clientOptInput).generate();
+
+        listFiles(output, 0);
+
+    }
+
+    private void listFiles(File dir, int level) {
+        File[] files = dir.listFiles();
+
+        String prefix = "JAXRS";
+        for (int index = 0; index < level; index++) {
+            prefix += "-";
+        }
+
+        for (File file : files) {
+            System.out.println(prefix + " " + file.getName());
+            if (file.isDirectory()) {
+                listFiles(file, level + 1);
+            }
+        }
+    }
+
+    @After
+    public void cleanUp() {
+        this.folder.delete();
+    }
+
+    @Test(description = "test generation for the default configuration options")
+    public void testGenerate() throws IOException {
+
+        /* Generate the code */
+        generateCode(new HashMap<>());
+
+        /* Verify the files which are expected are generated */
+        testModels();
+
+        /* Verify that the file generated is a class */
+        testIsClass(API_PATH, "InventoryApi");
+
+
+        /* Verify that the application class is generated */
+        final File application = new File(output, "/src/gen/java/io/swagger/api/RestApplication.java");
+        Assert.assertTrue(application.exists(), "Expected application file to exist");
+
+    }
+
+    @Test(description = "test generation for API interfaces")
+    public void testGenerateForInterface() throws IOException {
+
+        /* Generate the code */
+        final Map<String, Object> additionalProperties = new HashMap<>();
+        additionalProperties.put(JavaJAXRSSpecServerCodegen.INTERFACE_ONLY, true);
+        generateCode(additionalProperties);
+
+        /* Verify the model files which are expected are generated */
+        testModels();
+
+        /* Verify that the file generated is an interface */
+        testIsInterface(API_PATH, "InventoryApi");
+
+        /* Verify that the application class is not generated */
+        final File application = new File(output, "/src/gen/java/io/swagger/api/RestApplication.java");
+        Assert.assertFalse(application.exists(), "Expected application file to not exist");
+        
+    }
+
+    @Test(description = "test generation for Tags")
+    public void testGenerateForTags() throws IOException {
+        /* Generate the code */
+        final Map<String, Object> additionalProperties = new HashMap<>();
+        additionalProperties.put(AbstractJavaJAXRSServerCodegen.USE_TAGS, true);
+        generateCode(additionalProperties);
+
+        /* Verify the model files which are expected are generated */
+        testModels();
+
+        /* Verify that the API files generated are classes */
+        testIsClass(API_PATH, "AdminsApi");
+        testIsClass(API_PATH, "DevelopersApi");
+
+        /* Verify that the application class is generated */
+        final File application = new File(output, "/src/gen/java/io/swagger/api/RestApplication.java");
+        Assert.assertTrue(application.exists(), "Expected application file to exist");
+    }
+
+    @Test(description = "test generation for Tags & API interfaces")
+    public void testGenerateForTagsAndInterface() throws IOException {
+
+        /* Generate the code */
+        final Map<String, Object> additionalProperties = new HashMap<>();
+        additionalProperties.put(JavaJAXRSSpecServerCodegen.INTERFACE_ONLY, true);
+        additionalProperties.put(AbstractJavaJAXRSServerCodegen.USE_TAGS, true);
+        generateCode(additionalProperties);
+
+        /* Verify the model files which are expected are generated */
+        testModels();
+
+        /* Verify that the API files generated are interfaces */
+        testIsInterface(API_PATH, "AdminsApi");
+        testIsInterface(API_PATH, "DevelopersApi");
+
+        /* Verify that the application class is not generated */
+        final File application = new File(output, "/src/gen/java/io/swagger/api/RestApplication.java");
+        Assert.assertFalse(application.exists(), "Expected application file to not exist");
+
+    }
+
+    /**
+     * Helper method to verify that models were generated.
+     */
+    private void testModels() {
+
+        final List<String> expectedModels = Arrays.asList("Cat", "Dog", "House", "PartOne", "PartTwo", "PartThree",
+                "PartFour", "PartMaster", "Pet", "Pup");
+
+        for (String model : expectedModels) {
+            Assert.assertTrue(new File(output, "/src/gen/java/io/swagger/model/" + model + ".java").exists(),
+                    "Expected model to exist: " + model);
+        }
+    }
+
+    // private void assertFilesExist(final String path, final List<String> file)
+
+    /**
+     * Helper method to check that a generated file is a class. 
+     * @param path the path the file is expected to be in
+     * @param className the name of the class generated to check
+     * @throws IOException
+     */
+    private void testIsClass(final String path, final String className) throws IOException {
+        final String expectedContent = 
+            "public class " + className + " {";
+
+        final File controllerFile = new File(output, path + className + ".java");
+        final String content = FileUtils.readFileToString(controllerFile);
+
+        Assert.assertTrue(content.contains(expectedContent));
+    }
+
+    /**
+     * Helper method to check that a generated file is an interface. 
+     * @param path the path the file is expected to be in
+     * @param className the name of the class generated to check
+     * @throws IOException
+     */
+    private void testIsInterface(final String path, final String className) throws IOException {
+        final String expectedContent = 
+            "public interface " + className + " {";
+
+        final File controllerFile = new File(output, path + className + ".java");
+        final String content = FileUtils.readFileToString(controllerFile);
+
+        Assert.assertTrue(content.contains(expectedContent));
+    }
+}

--- a/src/test/resources/3_0_0/composed_schemas.yaml
+++ b/src/test/resources/3_0_0/composed_schemas.yaml
@@ -58,6 +58,24 @@ paths:
         '400':
           description: bad input parameter
 
+  /inventory/admin:
+    get:
+      tags:
+        - admins
+      summary: basic operation for an admin
+      operationId: inventoryAdmin
+      description: |
+        This does nothing special, here for testing tag based processing
+      responses:
+        '200':
+          description: The warehouse pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+
 components:
   schemas:
     PartOne:


### PR DESCRIPTION
Previously, the jaxrs-jersey language generator could generate files based on the tags an operation had, but the jaxrs-spec language could not. 

This change aims to:
* move the `useTags` configuration parameter into `AbstractJavaJAXRSServerCodegen` and remove it from extensions of this class
* move the logic to process operations by tag into the abstract class and out of the extensions of it
* add some test coverage to the `JavaJAXRSSpecServerCodegen` implementation.

I am marking this as a draft just now as there is still some cleanup required, but putting this up now for any early comments or questions. 