### PR TITLE
Add --use-oas2 command line argument support for standalone Swagger Codegen CLI

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaJAXRSServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaJAXRSServerCodegen.java
@@ -246,5 +246,8 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         this.useBeanValidation = useBeanValidation;
     }
 
-
+    @Override
+    public String getArgumentsLocation() {
+        return "/arguments/server.yaml";
+    }
 }

--- a/src/main/java/io/swagger/codegen/v3/generators/java/JavaCXFServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/JavaCXFServerCodegen.java
@@ -191,11 +191,6 @@ public class JavaCXFServerCodegen extends AbstractJavaJAXRSServerCodegen impleme
     }
 
     @Override
-    public String getArgumentsLocation() {
-        return "";
-    }
-
-    @Override
     public String getName() {
         return "jaxrs-cxf";
     }

--- a/src/main/java/io/swagger/codegen/v3/generators/java/JavaJAXRSSpecServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/JavaJAXRSSpecServerCodegen.java
@@ -6,7 +6,6 @@ import io.swagger.codegen.v3.CodegenModel;
 import io.swagger.codegen.v3.CodegenOperation;
 import io.swagger.codegen.v3.CodegenProperty;
 import io.swagger.codegen.v3.SupportingFile;
-import io.swagger.codegen.v3.generators.util.OpenAPIUtil;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -103,11 +102,6 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         if (!interfaceOnly) {
             writeOptional(outputFolder, new SupportingFile("RestApplication.mustache", (sourceFolder + '/' + invokerPackage).replace(".", "/"), "RestApplication.java"));
         }
-    }
-
-    @Override
-    public String getArgumentsLocation() {
-        return "";
     }
 
     @Override

--- a/src/main/java/io/swagger/codegen/v3/generators/java/JavaJerseyServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/JavaJerseyServerCodegen.java
@@ -144,11 +144,6 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
     }
 
     @Override
-    public String getArgumentsLocation() {
-        return "";
-    }
-
-    @Override
     public String getDefaultTemplateDir() {
         return JAXRS_TEMPLATE_DIRECTORY_NAME;
     }

--- a/src/main/java/io/swagger/codegen/v3/generators/java/JavaResteasyEapServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/JavaResteasyEapServerCodegen.java
@@ -106,11 +106,6 @@ public class JavaResteasyEapServerCodegen extends AbstractJavaJAXRSServerCodegen
     }
 
     @Override
-    public String getArgumentsLocation() {
-        return "";
-    }
-
-    @Override
     public String getDefaultTemplateDir() {
         return JAXRS_TEMPLATE_DIRECTORY_NAME +  "/resteasy/eap";
     }

--- a/src/main/java/io/swagger/codegen/v3/generators/java/JavaResteasyServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/JavaResteasyServerCodegen.java
@@ -95,12 +95,6 @@ public class JavaResteasyServerCodegen extends AbstractJavaJAXRSServerCodegen im
         }
     }
 
-
-    @Override
-    public String getArgumentsLocation() {
-        return "";
-    }
-
     @Override
     public String getDefaultTemplateDir() {
         return JAXRS_TEMPLATE_DIRECTORY_NAME +  "/resteasy";

--- a/src/main/resources/arguments/server.yaml
+++ b/src/main/resources/arguments/server.yaml
@@ -1,0 +1,4 @@
+arguments:
+  - option: "--use-oas2"
+    description: "use OpenAPI v2.0 (Swagger 1.5.x) annotations (by default, OpenAPI v3.0 is used)."
+    type: "boolean"


### PR DESCRIPTION
In the scope of https://github.com/swagger-api/swagger-codegen-generators/pull/101, it turned out that Swagger Codegen CLI does not support `--use-oas2` command line argument (to generate server stubs using OAS 2.x specification), which this pull request aims to fix. 

I have checked the usage of for `--use-oas2` for:

[ x ] jaxrs-spec
[ x ] jaxrs-cxf
[ x ] jaxrs-resteasy-eap
[ x ] jaxrs-resteasy
[ x ] jaxrs-jersey
[ x ] jaxrs-cxf-cdi
[ x ] jaxrs-di

Sample command line:

```
java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate     
    -l jaxrs-jersey    
    -i https://petstore.swagger.io/v2/swagger.json     
    -o samples    
    --use-oas2
```

@HugoMario please mind taking a look, thanks!