### PR TITLE
feat(kotlin): support primitive array types

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/kotlin/AbstractKotlinCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/kotlin/AbstractKotlinCodegen.java
@@ -53,7 +53,15 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegenConfig {
                 "kotlin.Array",
                 "kotlin.collections.List",
                 "kotlin.collections.Map",
-                "kotlin.collections.Set"
+                "kotlin.collections.Set",
+                "kotlin.ByteArray",
+                "kotlin.CharArray",
+                "kotlin.ShortArray",
+                "kotlin.IntArray",
+                "kotlin.LongArray",
+                "kotlin.FloatArray",
+                "kotlin.DoubleArray",
+                "kotlin.BooleanArray"
         ));
 
         // this includes hard reserved words defined by https://github.com/JetBrains/kotlin/blob/master/core/descriptors/src/org/jetbrains/kotlin/renderer/KeywordStringsGenerated.java
@@ -138,7 +146,15 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegenConfig {
                 "kotlin.Array",
                 "kotlin.collections.List",
                 "kotlin.collections.Set",
-                "kotlin.collections.Map"
+                "kotlin.collections.Map",
+                "kotlin.ByteArray",
+                "kotlin.CharArray",
+                "kotlin.ShortArray",
+                "kotlin.IntArray",
+                "kotlin.LongArray",
+                "kotlin.FloatArray",
+                "kotlin.DoubleArray",
+                "kotlin.BooleanArray"
         ));
 
         instantiationLibraryFunction = new HashSet<>(Arrays.asList(


### PR DESCRIPTION
## Description

Currently the kotlin generator is unaware of the primitive array types. This adds all of them pulled from the official Arrays.ky file in the kotlin repo https://github.com/JetBrains/kotlin/blob/master/core/builtins/native/kotlin/Arrays.kt

Fixes #749 

## Commit Body

this will prevent them from being incorrectly
imported as non existing swagger models

Fixes N/A