### PR TITLE
Handling "multi" collection format in parameterToString()

### DIFF
--- a/src/main/resources/handlebars/go/client.mustache
+++ b/src/main/resources/handlebars/go/client.mustache
@@ -138,6 +138,8 @@ func parameterToString(obj interface{}, collectionFormat string) string {
 		delimiter = "\t"
 	case "csv":
 		delimiter = ","
+	case "multi":
+		delimiter = ","
 	}
 
 	if reflect.TypeOf(obj).Kind() == reflect.Slice {


### PR DESCRIPTION
The `parameterToString()` method lacks assigning a delimiter when the `collectionFormat` parameter is "multi".