### PR TITLE
fix: bring back discriminator initialization to where it was before

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -1333,6 +1333,8 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         }
         codegenModel.getVendorExtensions().put(CodegenConstants.IS_ALIAS_EXT_NAME, typeAliases.containsKey(name));
 
+        codegenModel.discriminator = schema.getDiscriminator();
+
         if (schema.getXml() != null) {
             codegenModel.xmlPrefix = schema.getXml().getPrefix();
             codegenModel.xmlNamespace = schema.getXml().getNamespace();
@@ -1398,11 +1400,8 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
             // interfaces (intermediate models)
             if (allOf != null && !allOf.isEmpty()) {
 
-                if (schema.getDiscriminator() != null) {
-                    codegenModel.discriminator = schema.getDiscriminator();
-                    if (codegenModel.discriminator != null && codegenModel.discriminator.getPropertyName() != null) {
-                        codegenModel.discriminator.setPropertyName(toVarName(codegenModel.discriminator.getPropertyName()));
-                    }
+                if (codegenModel.discriminator != null && codegenModel.discriminator.getPropertyName() != null) {
+                    codegenModel.discriminator.setPropertyName(toVarName(codegenModel.discriminator.getPropertyName()));
                 }
 
                 for (int i = 0; i < allOf.size(); i++) {

--- a/src/test/java/io/swagger/codegen/v3/generators/java/JavaPolymorphicAnnotationCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/JavaPolymorphicAnnotationCodegenTest.java
@@ -1,0 +1,42 @@
+package io.swagger.codegen.v3.generators.java;
+
+import io.swagger.codegen.v3.ClientOptInput;
+import io.swagger.codegen.v3.DefaultGenerator;
+import io.swagger.codegen.v3.config.CodegenConfigurator;
+import org.apache.commons.io.FileUtils;
+import org.junit.rules.TemporaryFolder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+public class JavaPolymorphicAnnotationCodegenTest {
+
+    private TemporaryFolder folder = new TemporaryFolder();
+
+    @Test(description = "verify that jackson-polymorphism annotations are generated")
+    public void testParameterOrders() throws Exception {
+        this.folder.create();
+        final File output = this.folder.getRoot();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setLang("spring")
+            .setInputSpecURL("src/test/resources/3_0_0/polymorphicSchema.yaml")
+            .setOutputDir(output.getAbsolutePath());
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        new DefaultGenerator().opts(clientOptInput).generate();
+
+        final File petControllerFile = new File(output, "/src/main/java/io/swagger/model/PolymorphicResponse.java");
+        final String content = FileUtils.readFileToString(petControllerFile);
+
+        Assert.assertTrue(content.contains(
+            "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = \"type\", visible = true )\n" +
+                "@JsonSubTypes({\n" +
+                "        @JsonSubTypes.Type(value = Error.class, name = \"Error\"),\n" +
+                "        @JsonSubTypes.Type(value = Success.class, name = \"Success\"),\n" +
+                "})"));
+
+        this.folder.delete();
+    }
+}

--- a/src/test/resources/3_0_0/polymorphicSchema.yaml
+++ b/src/test/resources/3_0_0/polymorphicSchema.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.3
+info:
+  description: This is a simple API
+  version: "1.0.0"
+  title: Simple Inventory API
+servers:
+  - description: test definition
+    url: /
+paths:
+  /provision:
+    get:
+      tags:
+        - provision
+      summary: inheritanceTest
+      operationId: provision
+      description: inheritanceTest
+      responses:
+        200:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolymorphicResponse'
+
+components:
+  schemas:
+    PolymorphicResponse:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - Success
+            - Error
+          description: the descriminator
+      discriminator:
+        propertyName: type
+    Success:
+      allOf:
+        - $ref: '#/components/schemas/PolymorphicResponse'
+        - type: object
+          required:
+            - target
+          properties:
+            target:
+              type: string
+              description: some target value
+            dialogId:
+              type: string
+              format: uuid
+              description: some dialogId
+    Error:
+      allOf:
+        - $ref: '#/components/schemas/PolymorphicResponse'
+        - type: object
+          required:
+            - message
+          properties:
+            message:
+              type: string
+              description: the message describing the error


### PR DESCRIPTION
PR: https://github.com/swagger-api/swagger-codegen-generators/pull/620 , which was introduced in `1.0.19`, seems to be causing multiple issues (eg https://github.com/swagger-api/swagger-codegen-generators/issues/654).

This PR aims at fixing two issues:
fixes https://github.com/swagger-api/swagger-codegen-generators/issues/686
fixes https://github.com/swagger-api/swagger-codegen/issues/10198

Both issues are about missing polymorphic jackson annotations (`JsonSubTypes`, `JsonTypeInfo`).

The issue was caused by moving the initialization of the `discriminator` into the `ComposedSchema` block (https://github.com/swagger-api/swagger-codegen-generators/pull/620/commits/5d2238265a02d0ee3f19dc8dc9b4ed1e5d970b8c#diff-371437d4e9e09ea18f2ff29dbacd0e84L1279). 

In the examples mentioned in the issues, the model is not a `ComposedSchema`.
But the `discriminator` needs to be initialized for the annotations to be generated, but it is only for `ComposedSchema`s now.

This PR moves the initialization back to where it was before.
I am not quite sure if this has other side-effects, I did not see. It looks like there are a bunch of cases untested?!
Still I hope this might speed up things in case it gets approved.

Cheers,

Kai