### PR TITLE
[Swift 5] Fix Issue 10522 : Default parameters in generated model constructors.

### DIFF
--- a/src/main/resources/handlebars/swift5/modelObject.mustache
+++ b/src/main/resources/handlebars/swift5/modelObject.mustache
@@ -25,7 +25,7 @@ public struct {{classname}}: Codable {
 {{/allVars}}
 
 {{#hasVars}}
-    public init({{#allVars}}{{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allVars}}) {
+    public init({{#allVars}}{{name}}: {{{datatypeWithEnum}}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allVars}}) {
         {{#allVars}}
         self.{{name}} = {{name}}
         {{/allVars}}
@@ -84,4 +84,3 @@ public struct {{classname}}: Codable {
 {{/vendorExtensions.x-codegen-has-escaped-property-names}}{{/additionalPropertiesType}}
 
 }
-


### PR DESCRIPTION
## Issue Overview:
- This PR is targeted to fix the issue [#10522](https://github.com/swagger-api/swagger-codegen/issues/10522).
- As described in the issue, adding support for default parameters in the auto-generated Swift5 models' constructors.

## Fix:
Updating the moustache template by adding `nil` for the optional parameters in the `Swift5` model constructors similar to `Swift4` fixed by @deanWombourne's [PR](https://github.com/swagger-api/swagger-codegen-generators/pull/468).

Cc: @HugoMario 