### PR TITLE
Add CORS support to Python-Flask-Connexion server

### DIFF
--- a/src/main/resources/handlebars/pythonFlaskConnexion/__main__.mustache
+++ b/src/main/resources/handlebars/pythonFlaskConnexion/__main__.mustache
@@ -6,6 +6,7 @@
 {{/supportPython2}}
 
 import connexion
+from flask_cors import CORS
 
 from {{packageName}} import encoder
 
@@ -14,6 +15,10 @@ def main():
     app = connexion.App(__name__, specification_dir='./swagger/')
     app.app.json_encoder = encoder.JSONEncoder
     app.add_api('swagger.yaml', arguments={'title': '{{appName}}'}, pythonic_params=True)
+
+    # add CORS support
+    CORS(app.app)
+
     app.run(port={{serverPort}})
 
 

--- a/src/main/resources/handlebars/pythonFlaskConnexion/requirements.mustache
+++ b/src/main/resources/handlebars/pythonFlaskConnexion/requirements.mustache
@@ -1,4 +1,5 @@
 connexion == 2.6.0
+flask-cors == 3.0.10
 python_dateutil == 2.6.0
 {{#supportPython2}}
 typing == 3.5.2.2


### PR DESCRIPTION
The change adds CORS support with default configuration using the flask-cors package,
recommended in the Connexion documentation. The modification is minimal and permits
using the server with clients that enforce same origin policies.