### PR TITLE
Scope is not added properly in generated code

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/scala/ScalaClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/scala/ScalaClientCodegen.java
@@ -78,7 +78,8 @@ public class ScalaClientCodegen extends AbstractScalaCodegen {
                 gradleWrapperPackage.replace( ".", File.separator ), "gradle-wrapper.jar") );
 
         supportingFiles.add(new SupportingFile("build.sbt.mustache", "", "build.sbt"));
-
+        supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
+        
         importMapping.remove("List");
         importMapping.remove("Set");
         importMapping.remove("Map");

--- a/src/main/resources/handlebars/Java/README.mustache
+++ b/src/main/resources/handlebars/Java/README.mustache
@@ -151,8 +151,8 @@ Class | Method | HTTP request | Description
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}}  - {{scope}}: {{description}}
-{{/scopes}}
+{{#each scopes}}  - {{@key}}: {{this}}
+{{/each}}
 {{/isOAuth}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/Java/libraries/feign/ApiClient.mustache
+++ b/src/main/resources/handlebars/Java/libraries/feign/ApiClient.mustache
@@ -62,7 +62,7 @@ public class ApiClient {
         auth = new ApiKeyAuth({{#is this 'key-in-header'}}"header"{{/is}}{{#isNot this 'key-in-header'}}"query"{{/isNot}}, "{{keyParamName}}");
       {{/is}}
       {{#is this 'oauth'}}
-        auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{scope}}{{#hasMore}}, {{/hasMore}}{{/scopes}}");
+        auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#each scopes}}{{@key}}{{^@last}}, {{/@last}}{{/each}}");
       {{/is}}
       } else {{/authMethods}}{
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");

--- a/src/main/resources/handlebars/Java/libraries/retrofit/ApiClient.mustache
+++ b/src/main/resources/handlebars/Java/libraries/retrofit/ApiClient.mustache
@@ -62,7 +62,7 @@ public class ApiClient {
             {{#is this 'api-key'}}
                 auth = new ApiKeyAuth({{#is this 'key-in-header'}}"header"{{/is}}{{#isNot this 'key-in-header'}}"query"{{/isNot}}, "{{keyParamName}}");{{/is}}
             {{#is this 'oauth'}}
-                auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{scope}}{{#hasMore}}, {{/hasMore}}{{/scopes}}");
+                auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#each scopes}}{{@key}}{{^@last}}, {{/@last}}{{/each}}");
             {{/is}}
             } else {{/authMethods}}{
                 throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");

--- a/src/main/resources/handlebars/Java/libraries/retrofit2/ApiClient.mustache
+++ b/src/main/resources/handlebars/Java/libraries/retrofit2/ApiClient.mustache
@@ -70,7 +70,7 @@ public class ApiClient {
         auth = new ApiKeyAuth({{#is this 'key-in-header'}}"header"{{/is}}{{#isNot this 'key-in-header'}}"query"{{/isNot}}, "{{keyParamName}}");
         {{/is}}
         {{#is this 'oauth'}}
-        auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{scope}}{{#hasMore}}, {{/hasMore}}{{/scopes}}");
+        auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#each scopes}}{{@key}}{{^@last}}, {{/@last}}{{/each}}");
         {{/is}}
       } else {{/authMethods}}{
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");

--- a/src/main/resources/handlebars/JavaJaxRS/api.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/api.mustache
@@ -83,8 +83,8 @@ public class {{classname}}  {
     {{#useOas2}}
     @io.swagger.annotations.ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnBaseType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
         {{#authMethods}}@io.swagger.annotations.Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{@key}}", description = "{{this}}"){{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}",{{/vendorExtensions.x-tags}} })
@@ -95,8 +95,8 @@ public class {{classname}}  {
     {{^useOas2}}
     @Operation(summary = "{{{summary}}}", description = "{{{notes}}}"{{#hasAuthMethods}}, security = {
         {{#authMethods}}@SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}"{{scope}}"{{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}"{{@key}}"{{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })

--- a/src/main/resources/handlebars/JavaJaxRS/cxf-cdi/api.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/cxf-cdi/api.mustache
@@ -59,8 +59,8 @@ public class {{classname}}  {
     {{#useOas2}}
     @ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnBaseType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
         {{#authMethods}}@Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}@AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}@AuthorizationScope(scope = "{{@key}}", description = "{{this}}"){{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })
@@ -70,8 +70,8 @@ public class {{classname}}  {
     {{^useOas2}}
     @Operation(summary = "{{{summary}}}", description = "{{{notes}}}"{{#hasAuthMethods}}, security = {
         {{#authMethods}}@SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}"{{scope}}"{{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}"{{@key}}"{{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })

--- a/src/main/resources/handlebars/JavaJaxRS/di/api.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/di/api.mustache
@@ -66,8 +66,8 @@ public class {{classname}}  {
     {{#useOas2}}
     @io.swagger.annotations.ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnBaseType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
         {{#authMethods}}@io.swagger.annotations.Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{@key}}", description = "{{this}}"){{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}",{{/vendorExtensions.x-tags}} })
@@ -78,8 +78,8 @@ public class {{classname}}  {
     {{^useOas2}}
     @Operation(summary = "{{{summary}}}", description = "{{{notes}}}"{{#hasAuthMethods}}, security = {
         {{#authMethods}}@SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}"{{scope}}"{{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}"{{@key}}"{{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })

--- a/src/main/resources/handlebars/JavaJaxRS/libraries/jersey1/api.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/libraries/jersey1/api.mustache
@@ -47,8 +47,8 @@ public class {{classname}}  {
     {{#hasProduces}}@Produces({ {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }){{/hasProduces}}
     @io.swagger.annotations.ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnBaseType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
         {{#authMethods}}@io.swagger.annotations.Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{@key}}", description = "{{this}}"){{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })

--- a/src/main/resources/handlebars/JavaJaxRS/resteasy/api.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/resteasy/api.mustache
@@ -64,8 +64,8 @@ public class {{classname}}  {
     {{#useOas2}}
     @io.swagger.annotations.ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnBaseType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
         {{#authMethods}}@io.swagger.annotations.Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},{{/hasMore}}
-            {{/scopes}}
+            {{#each scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{@key}}", description = "{{this}}"){{^@last}},{{/@last}}
+            {{/each}}
         }{{/isOAuth}}){{#hasMore}},{{/hasMore}}
         {{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}",{{/vendorExtensions.x-tags}} })
@@ -77,8 +77,8 @@ public class {{classname}}  {
     {{^useOas2}}
     @Operation(summary = "{{{summary}}}", description = "{{{notes}}}"{{#hasAuthMethods}}, security = {
         {{#authMethods}}@SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}"{{scope}}"{{#hasMore}},{{/hasMore}}
-            {{/scopes}}
+            {{#each scopes}}"{{@key}}"{{^@last}},{{/@last}}
+            {{/each}}
         }{{/isOAuth}}){{#hasMore}},{{/hasMore}}
         {{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })

--- a/src/main/resources/handlebars/JavaJaxRS/resteasy/eap/api.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/resteasy/eap/api.mustache
@@ -58,8 +58,8 @@ public interface {{classname}}  {
     {{#useOas2}}
     @io.swagger.annotations.ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnBaseType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
         {{#authMethods}}@io.swagger.annotations.Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{@key}}", description = "{{this}}"){{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}",{{/vendorExtensions.x-tags}} })
@@ -70,8 +70,8 @@ public interface {{classname}}  {
     {{^useOas2}}
     @Operation(summary = "{{{summary}}}", description = "{{{notes}}}"{{#hasAuthMethods}}, security = {
         {{#authMethods}}@SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}"{{scope}}"{{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}"{{@key}}"{{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })

--- a/src/main/resources/handlebars/JavaJaxRS/spec/apiInterface.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/spec/apiInterface.mustache
@@ -5,8 +5,8 @@
     {{#useOas2}}
     @ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}"{{#hasAuthMethods}}, authorizations = {
         {{#authMethods}}@Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}@AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}@AuthorizationScope(scope = "{{@key}}", description = "{{this}}"){{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })
@@ -16,8 +16,8 @@
     {{^useOas2}}
     @Operation(summary = "{{{summary}}}", description = "{{{notes}}}"{{#hasAuthMethods}}, security = {
         {{#authMethods}}@SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}"{{scope}}"{{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}"{{@key}}"{{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })

--- a/src/main/resources/handlebars/JavaJaxRS/spec/apiMethod.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/spec/apiMethod.mustache
@@ -5,8 +5,8 @@
     {{#useOas2}}
     @ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnBaseType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
         {{#authMethods}}@Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}@AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}@AuthorizationScope(scope = "{{@key}}", description = "{{this}}"){{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })
@@ -17,8 +17,8 @@
     {{^useOas2}}
     @Operation(summary = "{{{summary}}}", description = "{{{notes}}}"{{#hasAuthMethods}}, security = {
         {{#authMethods}}@SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}"{{scope}}"{{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}"{{@key}}"{{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })

--- a/src/main/resources/handlebars/JavaSpring/api.mustache
+++ b/src/main/resources/handlebars/JavaSpring/api.mustache
@@ -120,8 +120,8 @@ public interface {{classname}} {
     {{^useOas2}}
     @Operation(summary = "{{{summary}}}", description = "{{{notes}}}"{{#hasAuthMethods}}, security = {
         {{#authMethods}}@SecurityRequirement(name = "{{name}}"{{#isOAuth}}, scopes = {
-            {{#scopes}}"{{scope}}"{{#hasMore}},
-            {{/hasMore}}{{/scopes}}
+            {{#each scopes}}"{{@key}}"{{^@last}},
+            {{/@last}}{{/each}}
         }{{/isOAuth}}){{#hasMore}},
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.x-tags}} })

--- a/src/main/resources/handlebars/csharp-dotnet2/README.mustache
+++ b/src/main/resources/handlebars/csharp-dotnet2/README.mustache
@@ -141,8 +141,8 @@ Authentication schemes defined for the API:
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}}  - {{scope}}: {{description}}
-{{/scopes}}
+{{#each scopes}}  - {{@key}}: {{this}}
+{{/each}}
 {{/isOAuth}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/csharp/README.mustache
+++ b/src/main/resources/handlebars/csharp/README.mustache
@@ -199,8 +199,8 @@ Authentication schemes defined for the API:
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}}  - {{scope}}: {{description}}
-{{/scopes}}
+{{#each scopes}}  - {{@key}}: {{this}}
+{{/each}}
 {{/isOAuth}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/dart/README.mustache
+++ b/src/main/resources/handlebars/dart/README.mustache
@@ -120,8 +120,8 @@ Class | Method | HTTP request | Description
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}} - **{{{scope}}}**: {{{description}}}
-{{/scopes}}
+{{#each scopes}} - **{{{@key}}}**: {{{this}}}
+{{/each}}
 {{/isOAuth}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/go/README.mustache
+++ b/src/main/resources/handlebars/go/README.mustache
@@ -68,8 +68,8 @@ r, err := client.Service.Operation(auth, args)
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}} - **{{{scope}}}**: {{{description}}}
-{{/scopes}}
+{{#each scopes}} - **{{@key}}**: {{this}}
+{{/each}}
 
 Example
 ```golang

--- a/src/main/resources/handlebars/javascript/README.mustache
+++ b/src/main/resources/handlebars/javascript/README.mustache
@@ -151,8 +151,8 @@ Class | Method | HTTP request | Description
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}}  - {{scope}}: {{description}}
-{{/scopes}}
+{{#each scopes}}  - {{@key}}: {{this}}
+{{/each}}
 {{/isOAuth}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/kotlin-client/README.mustache
+++ b/src/main/resources/handlebars/kotlin-client/README.mustache
@@ -78,8 +78,8 @@ Authentication schemes defined for the API:
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}}  - {{scope}}: {{description}}
-{{/scopes}}
+{{#each scopes}}  - {{@key}}: {{this}}
+{{/each}}
 {{/is}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/kotlin-server/README.mustache
+++ b/src/main/resources/handlebars/kotlin-server/README.mustache
@@ -77,8 +77,8 @@ Authentication schemes defined for the API:
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}}  - {{scope}}: {{description}}
-{{/scopes}}
+{{#each scopes}}  - {{@key}}: {{this}}
+{{/each}}
 {{/is}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/kotlin-server/libraries/ktor/README.mustache
+++ b/src/main/resources/handlebars/kotlin-server/libraries/ktor/README.mustache
@@ -94,8 +94,8 @@ Authentication schemes defined for the API:
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}}  - {{scope}}: {{description}}
-{{/scopes}}
+{{#each scopes}}  - {{@key}}: {{this}}
+{{/each}}
 {{/is}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/php/README.mustache
+++ b/src/main/resources/handlebars/php/README.mustache
@@ -130,8 +130,8 @@ Class | Method | HTTP request | Description
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}} - **{{{scope}}}**: {{{description}}}
-{{/scopes}}
+{{#each scopes}} - **{{@key}}**: {{this}}
+{{/each}}
 {{/isOAuth}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/python/README.mustache
+++ b/src/main/resources/handlebars/python/README.mustache
@@ -117,8 +117,8 @@ Class | Method | HTTP request | Description
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}} - **{{{scope}}}**: {{{description}}}
-{{/scopes}}
+{{#each scopes}} - **{{@key}}**: {{this}}
+{{/each}}
 {{/isOAuth}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/ruby/README.mustache
+++ b/src/main/resources/handlebars/ruby/README.mustache
@@ -124,8 +124,8 @@ Class | Method | HTTP request | Description
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}}  - {{scope}}: {{description}}
-{{/scopes}}
+{{#each scopes}}  - {{@key}}: {{this}}
+{{/each}}
 {{/isOAuth}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/scala/client/README.mustache
+++ b/src/main/resources/handlebars/scala/client/README.mustache
@@ -95,8 +95,8 @@ Class | Method | HTTP request | Description
 - **Flow**: {{flow}}
 - **Authorization URL**: {{authorizationUrl}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}}  - {{scope}}: {{description}}
-{{/scopes}}
+{{#each scopes}}  - {{@key}}: {{this}}
+{{/each}}
 {{/isOAuth}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/swift4/README.mustache
+++ b/src/main/resources/handlebars/swift4/README.mustache
@@ -53,8 +53,8 @@ Class | Method | HTTP request | Description
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}} - **{{{scope}}}**: {{{description}}}
-{{/scopes}}
+{{#each scopes}} - **{{@key}}**: {{{this}}}
+{{/each}}
 {{/is}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/swift5/README.mustache
+++ b/src/main/resources/handlebars/swift5/README.mustache
@@ -53,8 +53,8 @@ Class | Method | HTTP request | Description
 - **Flow**: {{{flow}}}
 - **Authorization URL**: {{{authorizationUrl}}}
 - **Scopes**: {{^scopes}}N/A{{/scopes}}
-{{#scopes}} - **{{{scope}}}**: {{{description}}}
-{{/scopes}}
+{{#each scopes}} - **{{@key}}**: {{this}}
+{{/each}}
 {{/isOAuth}}
 
 {{/authMethods}}

--- a/src/main/resources/handlebars/typescript-axios/apiInner.mustache
+++ b/src/main/resources/handlebars/typescript-axios/apiInner.mustache
@@ -92,7 +92,7 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
             // oauth required
             if (configuration && configuration.accessToken) {
                 const localVarAccessTokenValue = typeof configuration.accessToken === 'function'
-                    ? await configuration.accessToken("{{name}}", [{{#scopes}}"{{{scope}}}"{{^@last}}, {{/@last}}{{/scopes}}])
+                    ? await configuration.accessToken("{{name}}", [{{#each scopes}}"{{@key}}"{{^@last}}, {{/@last}}{{/each}}])
                     : await configuration.accessToken;
                 localVarHeaderParameter["Authorization"] = "Bearer " + localVarAccessTokenValue;
             }

--- a/src/main/resources/handlebars/typescript-fetch/api.mustache
+++ b/src/main/resources/handlebars/typescript-fetch/api.mustache
@@ -139,7 +139,7 @@ export const {{classname}}FetchParamCreator = function (configuration?: Configur
             // oauth required
             if (configuration && configuration.accessToken) {
 				const localVarAccessTokenValue = typeof configuration.accessToken === 'function'
-					? configuration.accessToken("{{name}}", [{{#scopes}}"{{{scope}}}"{{^@last}}, {{/@last}}{{/scopes}}])
+					? configuration.accessToken("{{name}}", [{{#each scopes}}"{{@key}}"{{^@last}}, {{/@last}}{{/each}}])
 					: configuration.accessToken;
                 localVarHeaderParameter["Authorization"] = "Bearer " + localVarAccessTokenValue;
             }


### PR DESCRIPTION
The `CodegenSecurity` model exposes `scopes` as a map which is not aligned within its usage in code generation templates. As the result, the `scopes` are not generated properly. The suggested fix is to update all templates to deal with scopes map in a proper way.

Verified against OAS2 / OAS3 generators, the following specification fragment

```
  securitySchemes:
    oauth2:
      type: oauth2
      flows:
        authorizationCode:
          scopes:
            read: read scope
            write: ""
```

On the generation side, the following code is being generated for OAS2 and OAS3 respectively.

```java
@ApiOperation(                                                             
  value = "",                                                              
  notes = "Search all people",                                             
  response = Person.class,                                                 
  responseContainer = "List",                                              
  authorizations = {                                                       
    @Authorization(                                                        
      value = "oauth2",                                                    
      scopes = {                                                           
        @AuthorizationScope(scope = "read", description = "read scope"),   
        @AuthorizationScope(scope = "write", description = "")             
      }                                                                    
    )                                                                      
  },                                                                       
  tags = {"people"}                                                        
)                                                                          
```

```java
@Operation(                                     
  summary = "",                                 
  description = "Search all people",            
  security = {                                  
    @SecurityRequirement(                       
      name = "oauth2",                          
      scopes = {"read", "write"}                
    )                                           
  },                                            
  tags = {"people"}                             
)                                               
```

```
    if ("oauth2".equals(authName)) {                                   
      auth = new OAuth(OAuthFlow.accessCode, "", "", "read, write");   
    }                                                           
```

Fixes https://github.com/swagger-api/swagger-codegen/issues/10225.
