### PR TITLE
Issue #860 Set super.equals for inheritance without properties

### DIFF
--- a/src/main/resources/handlebars/JavaSpring/pojo.mustache
+++ b/src/main/resources/handlebars/JavaSpring/pojo.mustache
@@ -121,7 +121,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     return {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
         {{/hasMore}}{{/vars}}{{#parent}} &&
         super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
   }
 
   @Override


### PR DESCRIPTION
Fixes #860

 - Set super.equals(o) for inheriting objects without own properties.