### PR TITLE
fix #862 - pack 'bytes' to body in the same way as 'str'

### DIFF
--- a/src/main/resources/handlebars/python/rest.mustache
+++ b/src/main/resources/handlebars/python/rest.mustache
@@ -179,7 +179,7 @@ class RESTClientObject(object):
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is
                 # provided in serialized form
-                elif isinstance(body, str):
+                elif isinstance(body, str) or isinstance(body, bytes):
                     request_body = body
                     r = self.pool_manager.request(
                         method, url,


### PR DESCRIPTION
fix #862 - upload binary data from python client generated:

pack 'bytes' to body in the same way as 'str'