### PR TITLE
[Typescript] Set parent for additional properties to Record<string, Child>

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/typescript/AbstractTypeScriptClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/typescript/AbstractTypeScriptClientCodegen.java
@@ -76,7 +76,8 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegenConf
                 "any",
                 "File",
                 "Error",
-                "Map"
+                "Map",
+                "Record"
                 ));
 
         languageGenericTypes = new HashSet<String>(Arrays.asList(
@@ -84,6 +85,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegenConf
         ));
 
         instantiationTypes.put("array", "Array");
+        instantiationTypes.put("map", "Record");
 
         typeMapping = new HashMap<String, String>();
         typeMapping.put("Array", "Array");
@@ -471,5 +473,16 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegenConf
     @Override
     public ISchemaHandler getSchemaHandler() {
         return new TypeScriptSchemaHandler(this);
+    }
+
+    @Override
+    public String toInstantiationType(Schema property) {
+        String instantiationType = super.toInstantiationType(property);
+
+        if (instantiationType != null && instantiationType.contains("<String, ")) {
+            return instantiationType.replaceFirst("<String, ", "<string, ");
+        }
+
+        return instantiationType;
     }
 }


### PR DESCRIPTION
This fixes #691

The gist of the issue is that currently, the typescript generators generate additional properties to have a parent of `null<String, Child>`. This is wrong in two dimensions. 

1. The parent type should not be `null`. I chose [`Record`](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeystype) in this PR as a default.
2. The parameter of the key is in upper case. This is wrong in Typescript and has to be lower case. This actually comes hard-coded from the DefaultCodegenConfig class. I guess this is a bug here, but I did not dare touching it since it affects all languages. 