### PR TITLE
Fix for stripping prefix on single enums

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -396,21 +396,25 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
     }
 
     /**
-     * Returns the common prefix of variables for enum naming
+     * Returns the common prefix of variables for enum naming if
+     * two or more variables are present.
      *
      * @param vars List of variable names
      * @return the common prefix for naming
      */
     public String findCommonPrefixOfVars(List<Object> vars) {
-        try {
-            String[] listStr = vars.toArray(new String[vars.size()]);
-            String prefix = StringUtils.getCommonPrefix(listStr);
-            // exclude trailing characters that should be part of a valid variable
-            // e.g. ["status-on", "status-off"] => "status-" (not "status-o")
-            return prefix.replaceAll("[a-zA-Z0-9]+\\z", "");
-        } catch (ArrayStoreException e) {
-            return "";
+        if (vars.size() > 1) {
+            try {
+                String[] listStr = vars.toArray(new String[vars.size()]);
+                String prefix = StringUtils.getCommonPrefix(listStr);
+                // exclude trailing characters that should be part of a valid variable
+                // e.g. ["status-on", "status-off"] => "status-" (not "status-o")
+                return prefix.replaceAll("[a-zA-Z0-9]+\\z", "");
+            } catch (ArrayStoreException e) {
+                // do nothing, just return default value
+            }
         }
+        return "";
     }
 
     /**

--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -1233,15 +1233,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
                 schema.set$ref(schema.get$ref().replace(modelName, newModelName));
             });
     }
-/*
-    @Override
-    public String findCommonPrefixOfVars(List<String> vars) {
-        String prefix = StringUtils.getCommonPrefix(vars.toArray(new String[vars.size()]));
-        // exclude trailing characters that should be part of a valid variable
-        // e.g. ["status-on", "status-off"] => "status-" (not "status-o")
-        return prefix.replaceAll("[a-zA-Z0-9]+\\z", "");
-    }
-*/
 
     @Override
     public String toEnumName(CodegenProperty property) {

--- a/src/test/java/io/swagger/codegen/v3/generators/DefaultCodegenConfigTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/DefaultCodegenConfigTest.java
@@ -28,6 +28,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -308,6 +310,22 @@ public class DefaultCodegenConfigTest {
         Assert.assertEquals(headerProperty.description, referencedHeader.getSchema().getDescription());
         Assert.assertEquals(headerProperty.datatype, "String");
         Assert.assertEquals(headerProperty.example, referencedHeader.getSchema().getExample());
+    }
+
+    @Test(dataProvider = "testCommonPrefixProvider")
+    public void testCommonPrefix(List<Object> vars, String expectedPrefix) {
+        DefaultCodegenConfig codegen = new P_DefaultCodegenConfig();
+        Assert.assertEquals(codegen.findCommonPrefixOfVars(vars), expectedPrefix);
+    }
+
+    @DataProvider(name = "testCommonPrefixProvider")
+    public Object[][] provideData_testCommonPrefix() {
+        return new Object[][]{
+            {Collections.singletonList("FOO_BAR"), ""},
+            {Arrays.asList("FOO_BAR", "FOO_BAZ"), "FOO_"},
+            {Arrays.asList("FOO_BAR", "FOO_BAZ", "TEST"), ""},
+            {Arrays.asList("STATUS-ON", "STATUS-OFF", "STATUS"), ""}
+        };
     }
 
     private static class P_DefaultCodegenConfig extends DefaultCodegenConfig{


### PR DESCRIPTION
This PR resolves a bug when using a single enum is used that a "common prefix" is found resulting in the enum's name being cropped: https://github.com/swagger-api/swagger-codegen/issues/7725

The above issues was fixed in Codegen OAS 2, this PR applies the same fix https://github.com/swagger-api/swagger-codegen/pull/7726, plus the addition of unit tests.
