### PR TITLE
[typescript-fetch] use isomorphic-fetch

### DIFF
--- a/src/main/resources/handlebars/typescript-fetch/api.mustache
+++ b/src/main/resources/handlebars/typescript-fetch/api.mustache
@@ -3,7 +3,7 @@
 {{>licenseInfo}}
 
 import * as url from "url";
-import * as portableFetch from "portable-fetch";
+import * as isomorphicFetch from "isomorphic-fetch";
 import { Configuration } from "./configuration";
 
 const BASE_PATH = "{{{basePath}}}".replace(/\/+$/, "");
@@ -46,7 +46,7 @@ export interface FetchArgs {
 export class BaseAPI {
     protected configuration: Configuration;
 
-    constructor(configuration?: Configuration, protected basePath: string = BASE_PATH, protected fetch: FetchAPI = portableFetch) {
+    constructor(configuration?: Configuration, protected basePath: string = BASE_PATH, protected fetch: FetchAPI = isomorphicFetch) {
         if (configuration) {
             this.configuration = configuration;
             this.basePath = configuration.basePath || this.basePath;
@@ -262,7 +262,7 @@ export const {{classname}}Fp = function(configuration?: Configuration) {
          */
         {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Response{{/returnType}}> {
             const localVarFetchArgs = {{classname}}FetchParamCreator(configuration).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options);
-            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+            return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
                         return response{{#returnType}}.json(){{/returnType}};

--- a/src/main/resources/handlebars/typescript-fetch/custom.d.mustache
+++ b/src/main/resources/handlebars/typescript-fetch/custom.d.mustache
@@ -1,2 +1,2 @@
-declare module 'portable-fetch';
+declare module 'isomorphic-fetch';
 declare module 'url';

--- a/src/main/resources/handlebars/typescript-fetch/package.mustache
+++ b/src/main/resources/handlebars/typescript-fetch/package.mustache
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "portable-fetch": "^3.0.0"
+    "isomorphic-fetch": "^3.0.0"
   },
   "devDependencies": {
     "@types/jest": "^25.2.1",

--- a/src/main/resources/mustache/typescript-fetch/package.mustache
+++ b/src/main/resources/mustache/typescript-fetch/package.mustache
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "portable-fetch": "^3.0.0"
+    "isomorphic-fetch": "^3.0.0"
   },
   "devDependencies": {
     "@types/jest": "^25.2.1",


### PR DESCRIPTION
For `typescript-fetch`, the generated client uses the [`portable-fetch`](https://www.npmjs.com/package/portable-fetch) package. It's a fork of the very popular [`isomorphic-fetch`](https://www.npmjs.com/package/isomorphic-fetch) package. The fork has been unmaintained for 4 years and provides no documentation on its motives.

This PR replaces the fork with the original (more up to date) package. I think it's not good for codegen to rely on random forks for such simple tasks (a polyfill for `fetch()`). If users have specific needs regarding the `fetch()` implementation, the generated code allows them to pass it on the constructor.