### PR TITLE
[typescript] fix type aliases generation

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/typescript/AbstractTypeScriptClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/typescript/AbstractTypeScriptClientCodegen.java
@@ -33,6 +33,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static io.swagger.codegen.v3.CodegenConstants.IS_ENUM_EXT_NAME;
+import static io.swagger.codegen.v3.CodegenConstants.IS_OBJECT_EXT_NAME;
 import static io.swagger.codegen.v3.generators.handlebars.ExtensionHelper.getBooleanValue;
 
 public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegenConfig {
@@ -224,6 +225,15 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegenConf
     public String toModelFilename(String name) {
         // should be the same as the model name
         return toModelName(name);
+    }
+
+    @Override
+    public CodegenModel fromModel(String name, Schema schema, Map<String, Schema> allDefinitions) {
+        final CodegenModel codegenModel = super.fromModel(name, schema, allDefinitions);
+        if (isObjectSchema(schema) || schema instanceof MapSchema) {
+            codegenModel.getVendorExtensions().put(CodegenConstants.IS_OBJECT_EXT_NAME, Boolean.TRUE);
+        }
+        return codegenModel;
     }
 
     @Override

--- a/src/main/resources/handlebars/typescript-fetch/api.mustache
+++ b/src/main/resources/handlebars/typescript-fetch/api.mustache
@@ -68,7 +68,7 @@ export class RequiredError extends Error {
 }
 
 {{#models}}
-{{#model}}{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{>modelGeneric}}{{/isEnum}}{{/model}}
+{{#model}}{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#isObject}}{{>modelGeneric}}{{/isObject}}{{^isObject}}{{>modelAlias}}{{/isObject}}{{/isEnum}}{{/model}}
 {{/models}}
 {{#apiInfo}}{{#apis}}{{#operations}}
 /**

--- a/src/main/resources/handlebars/typescript-fetch/modelAlias.mustache
+++ b/src/main/resources/handlebars/typescript-fetch/modelAlias.mustache
@@ -1,0 +1,27 @@
+/**
+ * {{{description}}}
+ * @export
+ */
+export type {{classname}} = {{#parent}}{{{parent}}}{{/parent}}{{^parent}}{{{dataType}}}{{/parent}}{{#hasEnums}}
+
+/**
+ * @export
+ * @namespace {{classname}}
+ */
+export namespace {{classname}} {
+{{#vars}}
+    {{#isEnum}}
+    /**
+     * @export
+     * @enum {string}
+     */
+    export enum {{enumName}} {
+    {{#allowableValues}}
+        {{#enumVars}}
+        {{{name}}} = <any> {{{value}}}{{^@last}},{{/@last}}
+        {{/enumVars}}
+    {{/allowableValues}}
+    }
+    {{/isEnum}}
+{{/vars}}
+}{{/hasEnums}}


### PR DESCRIPTION
For schemas of primitive types:

~~~ yaml
components:
  schemas:
    Timestamp:
      description: UTC timestamp in milliseconds since epoch
      type: number
~~~

It was previously generating invalid code:

~~~ typescript
/**
 * UTC timestamp in milliseconds since epoch
 * @export
 */
export interface Timestamp {
}
~~~

Now it generates:

~~~ typescript
/**
 * UTC timestamp in milliseconds since epoch
 * @export
 */
export type Timestamp = number
~~~