### PR TITLE
[RUBY] Add support for passing client key password (keypasswd)

### DIFF
--- a/src/main/resources/handlebars/ruby/api_client.mustache
+++ b/src/main/resources/handlebars/ruby/api_client.mustache
@@ -103,7 +103,8 @@ module {{moduleName}}
         :ssl_verifyhost => _verify_ssl_host,
         :sslcert => @config.cert_file,
         :sslkey => @config.key_file,
-        :verbose => @config.debugging
+        :verbose => @config.debugging,
+        :keypasswd => @config.key_password
       }
 
       # set custom cert, if provided

--- a/src/main/resources/handlebars/ruby/configuration.mustache
+++ b/src/main/resources/handlebars/ruby/configuration.mustache
@@ -106,6 +106,10 @@ module {{moduleName}}
     # Client private key file (for client certificate)
     attr_accessor :key_file
 
+    ### TLS/SSL setting
+    # Client private key passphrase (for client certificate)
+    attr_accessor :key_password
+
     # Set this to customize parameters encoding of array parameter with multi collectionFormat.
     # Default to nil.
     #
@@ -130,6 +134,7 @@ module {{moduleName}}
       @params_encoding = nil
       @cert_file = nil
       @key_file = nil
+      @key_password = nil
       @debugging = false
       @inject_format = false
       @force_ending_format = false


### PR DESCRIPTION
### This PR addresses the following issues when generating a `ruby` client SDK:

- [Add support for passing client key password to AP]( https://github.com/swagger-api/swagger-codegen-generators/issues/885)

### Files modified (`handlebars`)

## configuration.mustache
Added and initialized accessor key_password
``` ruby
    ### TLS/SSL setting
    # Client private key passphrase (for client certificate)
    attr_accessor :key_password

    def initialize
      @scheme = '{{scheme}}'
      @host = '{{host}}'
      @base_path = '{{basePath}}'
      @api_key = {}
      @api_key_prefix = {}
      @timeout = 0
      @client_side_validation = true
      @verify_ssl = true
      @verify_ssl_host = true
      @params_encoding = nil
      @cert_file = nil
      @key_file = nil
      @key_password = nil
      @debugging = false
      @inject_format = false
      @force_ending_format = false
      @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)

      yield(self) if block_given?
    end
```

## api_client.mustache
Assigned the certificate key_password to the request options keypasswd.
``` ruby
      req_opts = {
        :method => http_method,
        :headers => header_params,
        :params => query_params,
        :params_encoding => @config.params_encoding,
        :timeout => @config.timeout,
        :ssl_verifypeer => @config.verify_ssl,
        :ssl_verifyhost => _verify_ssl_host,
        :sslcert => @config.cert_file,
        :sslkey => @config.key_file,
        :verbose => @config.debugging,
        :keypasswd => @config.key_password
      }
```

