### PR TITLE
[RUBY] Added logic to properly generate a gem if using windows OS

### DIFF
--- a/src/main/resources/handlebars/ruby/gemspec.mustache
+++ b/src/main/resources/handlebars/ruby/gemspec.mustache
@@ -29,8 +29,8 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 
-  s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.test_files    = `find spec/*`.split("\n")
+  s.files         = Dir.glob("**/*")
+  s.test_files    = Dir.glob("spec/**/*")
   s.executables   = []
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
### This PR addresses the issue of generating a gem from a windows platform for a `ruby` client SDK :

- [Properly generate a gem for Windows OS](https://github.com/swagger-api/swagger-codegen/issues/10894)

### File modified (`configuration.mustache`)
Change the Linux based `file` command to a ruby `Dir.glob()` command
``` ruby
# -*- encoding: utf-8 -*-

=begin
{{> api_info}}
=end

$:.push File.expand_path("../lib", __FILE__)
require "{{gemName}}/version"

Gem::Specification.new do |s|
  s.name        = "{{gemName}}{{^gemName}}{{{appName}}}{{/gemName}}"
  s.version     = {{moduleName}}::VERSION
  s.platform    = Gem::Platform::RUBY
  s.authors     = ["{{gemAuthor}}{{^gemAuthor}}Swagger-Codegen{{/gemAuthor}}"]
  s.email       = ["{{gemAuthorEmail}}{{^gemAuthorEmail}}{{infoEmail}}{{/gemAuthorEmail}}"]
  s.homepage    = "{{gemHomepage}}{{^gemHomepage}}https://github.com/swagger-api/swagger-codegen{{/gemHomepage}}"
  s.summary     = "{{gemSummary}}{{^gemSummary}}{{{appName}}} Ruby Gem{{/gemSummary}}"
  s.description = "{{gemDescription}}{{^gemDescription}}{{{appDescription}}}{{^appDescription}}{{{appName}}} Ruby Gem{{/appDescription}}{{/gemDescription}}"
  {{#gemLicense}}
  s.license     = '{{{gemLicense}}}'
  {{/gemLicense}}
  {{^gemLicense}}
  s.license     = "Unlicense"
  {{/gemLicense}}
  s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 1.9{{/gemRequiredRubyVersion}}"

  s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
  s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'

  s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
  
  s.files         = Dir.glob("**/*")
  s.test_files    = Dir.glob("spec/**/*")
  s.executables   = []
  s.require_paths = ["lib"]
end
```
