### PR TITLE
fix nodejs-server parameter order #906

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/nodejs/NodeJSServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/nodejs/NodeJSServerCodegen.java
@@ -438,9 +438,12 @@ public class NodeJSServerCodegen extends DefaultCodegenConfig {
     protected void configuresParameterForMediaType(CodegenOperation codegenOperation, List<CodegenContent> codegenContents) {
         if (codegenContents.isEmpty()) {
             CodegenContent content = new CodegenContent();
-            content.getParameters().addAll(codegenOperation.allParams);
+            content.getParameters().addAll(codegenOperation.queryParams);
+            content.getParameters().addAll(codegenOperation.pathParams);
+            content.getParameters().addAll(codegenOperation.headerParams);
+            content.getParameters().addAll(codegenOperation.cookieParams);
             codegenContents.add(content);
-
+            addHasMore(content.getParameters());
             codegenOperation.getContents().add(content);
             return;
         }

--- a/src/test/java/io/swagger/codegen/v3/generators/nodejs/NodeJSServerCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/nodejs/NodeJSServerCodegenTest.java
@@ -32,6 +32,7 @@ public class NodeJSServerCodegenTest  extends AbstractCodegenTest {
         final String content = FileUtils.readFileToString(petControllerFile);
 
         Assert.assertTrue(content.contains("module.exports.feedPet = function feedPet (req, res, next, body, petType, status, petId, token, sessionId)"));
+        Assert.assertTrue(content.contains("module.exports.getPetById = function getPetById (req, res, next, queryParam1, petId)"));
 
         this.folder.delete();
     }

--- a/src/test/resources/3_0_0/petstore.yaml
+++ b/src/test/resources/3_0_0/petstore.yaml
@@ -158,6 +158,11 @@ paths:
           schema:
             type: integer
             format: int64
+        - name: queryParam1
+          in: query
+          description: A bogus field for testing order of path and query parameters
+          schema:
+            type: string
       responses:
         '200':
           description: successful operation


### PR DESCRIPTION
These changes are for issue #906 

This adds the operation parameters in the correct order as expected by the "oas3-tools" library.