### PR TITLE
909: Fixed bug where an enum value could end up being called "_" whic…

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -492,6 +492,15 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         }
     }
 
+    protected String escapeUnderscore(String name) {
+        // Java 8 discourages naming things _, but Java 9 does not allow it.
+        if("_".equals(name)) {
+            return "_u";
+        } else {
+            return name;
+        }
+    }
+
     @Override
     public String escapeReservedWord(String name) {
         if(this.reservedWordsMappings().containsKey(name)) {
@@ -562,11 +571,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
             return "propertyClass";
         }
 
-        if("_".equals(name)) {
-            name = "_u";
-        }
+        name = escapeUnderscore(name);
 
-        // if it's all uppper case, do nothing
+        // if it's all upper case, do nothing
         if (name.matches("^[A-Z_]*$")) {
             return name;
         }
@@ -1264,7 +1271,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         if (var.matches("\\d.*")) {
             return "_" + var;
         } else {
-            return var;
+            return escapeUnderscore(var).toUpperCase();
         }
     }
 

--- a/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
@@ -24,6 +24,11 @@ public class AbstractJavaCodegenTest {
     }
 
     @Test
+    public void toEnumVarNameShouldNotCreateSingleUnderscore() throws Exception {
+        Assert.assertEquals("_U", fakeJavaCodegen.toEnumVarName(",.", "String"));
+    }
+
+    @Test
     public void toVarNameShouldAvoidOverloadingGetClassMethod() throws Exception {
         Assert.assertEquals("propertyClass", fakeJavaCodegen.toVarName("class"));
         Assert.assertEquals("propertyClass", fakeJavaCodegen.toVarName("_class"));
@@ -96,6 +101,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(fakeJavaCodegen.toVarName("user_name"), "userName");
         Assert.assertEquals(fakeJavaCodegen.toVarName("_user_name"), "_userName");
         Assert.assertEquals(fakeJavaCodegen.toVarName(":user_name"), "userName");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("_"), "u");
     }
 
     @Test


### PR DESCRIPTION
…h is invalid in Java >= 9.

Fixes #909 