### PR TITLE
Fixed #10129 for swagger-codegen where python was getting the type "O…

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
@@ -469,6 +469,10 @@ public class PythonClientCodegen extends DefaultCodegenConfig {
 
     @Override
     public String toModelName(String name) {
+        if (name == null) {
+            // sanitizeName will return "Object" for null, but this is called "object" in python
+            return "object";
+        }
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         // remove dollar sign
         name = name.replaceAll("$", "");

--- a/src/test/java/io/swagger/codegen/v3/generators/python/PythonClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/python/PythonClientCodegenTest.java
@@ -1,0 +1,41 @@
+package io.swagger.codegen.v3.generators.python;
+
+import io.swagger.codegen.v3.generators.AbstractCodegenTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PythonClientCodegenTest extends AbstractCodegenTest {
+    @Test
+    public void testToModelName() {
+        PythonClientCodegen pythonClientCodegen = new PythonClientCodegen();
+
+        // no type - this is 'object' in Python
+        Assert.assertEquals(pythonClientCodegen.toModelName(null), "object");
+        // assume this is a model type - "null" is not special in Python
+        Assert.assertEquals(pythonClientCodegen.toModelName("null"), "Null");
+        // reserved word
+        Assert.assertEquals(pythonClientCodegen.toModelName("return"), "ModelReturn");
+        Assert.assertEquals(pythonClientCodegen.toModelName("None"), "ModelNone");
+        // $
+        Assert.assertEquals(pythonClientCodegen.toModelName("my$result"), "Myresult");
+        // Starts with number
+        Assert.assertEquals(pythonClientCodegen.toModelName("999Bad"), "Model999Bad");
+        // Camel Case
+        Assert.assertEquals(pythonClientCodegen.toModelName("camel_case"), "CamelCase");
+    }
+
+    @Test
+    public void testToModelNamePrefixSuffix() {
+        PythonClientCodegen pythonClientCodegen = new PythonClientCodegen();
+        pythonClientCodegen.setModelNamePrefix("xprefixx");
+
+        // Camel Case
+        Assert.assertEquals(pythonClientCodegen.toModelName("camel_case"), "XprefixxCamelCase");
+
+        pythonClientCodegen.setModelNamePrefix(null);
+        pythonClientCodegen.setModelNameSuffix("xsuffixx");
+
+        // Camel Case
+        Assert.assertEquals(pythonClientCodegen.toModelName("camel_case"), "CamelCaseXsuffixx");
+    }
+}


### PR DESCRIPTION
…bject" when it should be "object". See https://github.com/swagger-api/swagger-codegen/issues/10129