### PR TITLE
mustache: supporting java XmlSeeAlso annotation

### DIFF
--- a/src/main/resources/handlebars/Java/xmlAnnotation.mustache
+++ b/src/main/resources/handlebars/Java/xmlAnnotation.mustache
@@ -1,4 +1,11 @@
 {{#withXml}}
 @XmlRootElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{classname}}{{/xmlName}}")
 @XmlAccessorType(XmlAccessType.FIELD)
+{{#discriminator}}
+@XmlSeeAlso({
+  {{#children}}
+  {{classname}}.class,
+  {{/children}}
+})
+{{/discriminator}}
 {{#jackson}}@JacksonXmlRootElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{classname}}{{/xmlName}}"){{/jackson}}{{/withXml}}

--- a/src/main/resources/handlebars/JavaMicronaut/xmlAnnotation.mustache
+++ b/src/main/resources/handlebars/JavaMicronaut/xmlAnnotation.mustache
@@ -3,4 +3,11 @@
 @JacksonXmlRootElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{classname}}{{/xmlName}}")
 {{/jackson}}
 @XmlRootElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{classname}}{{/xmlName}}")
-@XmlAccessorType(XmlAccessType.FIELD){{/withXml}}
+@XmlAccessorType(XmlAccessType.FIELD)
+{{#discriminator}}
+@XmlSeeAlso({
+  {{#children}}
+  {{classname}}.class,
+  {{/children}}
+})
+{{/discriminator}}{{/withXml}}

--- a/src/main/resources/handlebars/JavaSpring/xmlAnnotation.mustache
+++ b/src/main/resources/handlebars/JavaSpring/xmlAnnotation.mustache
@@ -3,4 +3,11 @@
 @JacksonXmlRootElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{classname}}{{/xmlName}}")
 {{/jackson}}
 @XmlRootElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{classname}}{{/xmlName}}")
-@XmlAccessorType(XmlAccessType.FIELD){{/withXml}}
+@XmlAccessorType(XmlAccessType.FIELD)
+{{#discriminator}}
+@XmlSeeAlso({
+  {{#children}}
+  {{classname}}.class,
+  {{/children}}
+})
+{{/discriminator}}{{/withXml}}


### PR DESCRIPTION
Added support for `@XmlSeeAlso` java annotation for inherited classes when using `withXml` config. 