### PR TITLE
Fixes getter and setter name problems for subtypes

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -42,9 +41,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static io.swagger.codegen.v3.CodegenConstants.HAS_ENUMS_EXT_NAME;
 import static io.swagger.codegen.v3.CodegenConstants.IS_ENUM_EXT_NAME;

--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -41,7 +42,9 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static io.swagger.codegen.v3.CodegenConstants.HAS_ENUMS_EXT_NAME;
 import static io.swagger.codegen.v3.CodegenConstants.IS_ENUM_EXT_NAME;
@@ -1022,7 +1025,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
                     continue;
                 }
                 boolean hasConflict = parentModel.vars.stream()
-                    .anyMatch(parentProperty -> parentProperty.name.equals(codegenProperty.name) && !parentProperty.datatype.equals(codegenProperty.datatype));
+                    .anyMatch(parentProperty ->
+                        (parentProperty.name.equals(codegenProperty.name) ||
+                            parentProperty.getGetter().equals(codegenProperty.getGetter()) ||
+                            parentProperty.getSetter().equals(codegenProperty.getSetter()) &&
+                        !parentProperty.datatype.equals(codegenProperty.datatype)));
                 if (hasConflict) {
                     codegenProperty.name = toVarName(codegenModel.name + "_" + codegenProperty.name);
                     codegenProperty.getter = toGetter(codegenProperty.name);

--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -1033,7 +1033,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
                 if (hasConflict) {
                     codegenProperty.name = toVarName(codegenModel.name + "_" + codegenProperty.name);
                     codegenProperty.getter = toGetter(codegenProperty.name);
-                    codegenProperty.setter = toGetter(codegenProperty.name);
+                    codegenProperty.setter = toSetter(codegenProperty.name);
                     break;
                 }
                 parentModel = parentModel.parentModel;

--- a/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
@@ -2,6 +2,8 @@ package io.swagger.codegen.v3.generators.java;
 
 import io.swagger.codegen.v3.CodegenArgument;
 import io.swagger.codegen.v3.CodegenConstants;
+import io.swagger.codegen.v3.CodegenModel;
+import io.swagger.codegen.v3.CodegenProperty;
 import io.swagger.codegen.v3.CodegenType;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -10,7 +12,11 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class AbstractJavaCodegenTest {
 
@@ -161,6 +167,126 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xxx.yyyyy.invoker.xxxxxx");
         Assert.assertEquals(codegen.getSortParamsByRequiredFlag(), Boolean.TRUE);
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG), Boolean.TRUE);
+    }
+
+    @Test
+    public void testFixUpParentAndInterfaces_propertyNameDifferent_getterSetterSame_typeDifferent() {
+        AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
+
+        CodegenModel parentModel = new CodegenModel();
+        parentModel.name = "parent_type";
+        CodegenModel childModel = new CodegenModel();
+        childModel.name = "child_type";
+        childModel.parentModel = parentModel;
+        parentModel.children = new ArrayList<>();
+
+        CodegenProperty parentValueProperty1 = new CodegenProperty();
+        parentValueProperty1.name = "value";
+        parentValueProperty1.baseName = "value";
+        parentValueProperty1.getter = "getValue";
+        parentValueProperty1.setter = "setValue";
+        parentValueProperty1.datatype = "value_type";
+        CodegenProperty parentValueProperty2 = new CodegenProperty();
+        parentValueProperty2.name = "other_value";
+        parentValueProperty2.baseName = "other_value";
+        parentValueProperty2.getter = "getOtherValue";
+        parentValueProperty2.setter = "setOtherValue";
+        parentValueProperty2.datatype = "other_type";
+        parentModel.vars = new ArrayList<>();
+        parentModel.vars.add(parentValueProperty1);
+        parentModel.vars.add(parentValueProperty2);
+
+        CodegenProperty childValueProperty1 = new CodegenProperty();
+        childValueProperty1.name = "_value"; // different to parent "value"
+        childValueProperty1.baseName = "_value";
+        childValueProperty1.getter = "getValue"; // same as parent "getValue"
+        childValueProperty1.setter = "setValue"; // same as parent "setValue"
+        childValueProperty1.datatype = "different_type"; // different to parent "value_type"
+        CodegenProperty childValueProperty2 = new CodegenProperty();
+        childValueProperty2.name = "third_value";
+        childValueProperty2.baseName = "third_value";
+        childValueProperty2.getter = "getThirdValue";
+        childValueProperty2.setter = "setThirdValue";
+        childValueProperty2.datatype = "other_type";
+        childModel.vars = new ArrayList<>();
+        childModel.vars.add(childValueProperty1);
+        childModel.vars.add(childValueProperty2);
+
+        Map<String, CodegenModel> allModels = new HashMap<>();
+        allModels.put(parentModel.name, parentModel);
+        allModels.put(childModel.name, childModel);
+
+        codegen.fixUpParentAndInterfaces(childModel, Collections.EMPTY_MAP);
+        Assert.assertEquals(childModel.vars.get(0).baseName, "_value");
+        Assert.assertEquals(childModel.vars.get(0).name, "childTypeValue");
+        Assert.assertEquals(childModel.vars.get(0).getter, "getChildTypeValue");
+        Assert.assertEquals(childModel.vars.get(0).setter, "setChildTypeValue");
+
+        // unchanged
+        Assert.assertEquals(childModel.vars.get(1).baseName, childValueProperty2.baseName);
+        Assert.assertEquals(childModel.vars.get(1).name, childValueProperty2.name);
+        Assert.assertEquals(childModel.vars.get(1).getter, childValueProperty2.getter);
+        Assert.assertEquals(childModel.vars.get(1).setter, childValueProperty2.setter);
+    }
+
+    @Test
+    public void testFixUpParentAndInterfaces_propertyNameSame_getterSetterSame_typeDifferent() {
+        AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
+
+        CodegenModel parentModel = new CodegenModel();
+        parentModel.name = "parent_type";
+        CodegenModel childModel = new CodegenModel();
+        childModel.name = "child_type";
+        childModel.parentModel = parentModel;
+        parentModel.children = new ArrayList<>();
+
+        CodegenProperty parentValueProperty1 = new CodegenProperty();
+        parentValueProperty1.name = "value";
+        parentValueProperty1.baseName = "value";
+        parentValueProperty1.getter = "getValue";
+        parentValueProperty1.setter = "setValue";
+        parentValueProperty1.datatype = "value_type";
+        CodegenProperty parentValueProperty2 = new CodegenProperty();
+        parentValueProperty2.name = "other_value";
+        parentValueProperty2.baseName = "other_value";
+        parentValueProperty2.getter = "getOtherValue";
+        parentValueProperty2.setter = "setOtherValue";
+        parentValueProperty2.datatype = "other_type";
+        parentModel.vars = new ArrayList<>();
+        parentModel.vars.add(parentValueProperty1);
+        parentModel.vars.add(parentValueProperty2);
+
+        CodegenProperty childValueProperty1 = new CodegenProperty();
+        childValueProperty1.name = "value"; // same as parent "value"
+        childValueProperty1.baseName = "value";
+        childValueProperty1.getter = "getValue"; // same as parent "getValue"
+        childValueProperty1.setter = "setValue"; // same as parent "setValue"
+        childValueProperty1.datatype = "different_type"; // different to parent "value_type"
+        CodegenProperty childValueProperty2 = new CodegenProperty();
+        childValueProperty2.name = "third_value";
+        childValueProperty2.baseName = "third_value";
+        childValueProperty2.getter = "getThirdValue";
+        childValueProperty2.setter = "setThirdValue";
+        childValueProperty2.datatype = "other_type";
+        childModel.vars = new ArrayList<>();
+        childModel.vars.add(childValueProperty1);
+        childModel.vars.add(childValueProperty2);
+
+        Map<String, CodegenModel> allModels = new HashMap<>();
+        allModels.put(parentModel.name, parentModel);
+        allModels.put(childModel.name, childModel);
+
+        codegen.fixUpParentAndInterfaces(childModel, Collections.EMPTY_MAP);
+        Assert.assertEquals(childModel.vars.get(0).baseName, "value");
+        Assert.assertEquals(childModel.vars.get(0).name, "childTypeValue");
+        Assert.assertEquals(childModel.vars.get(0).getter, "getChildTypeValue");
+        Assert.assertEquals(childModel.vars.get(0).setter, "setChildTypeValue");
+
+        // unchanged
+        Assert.assertEquals(childModel.vars.get(1).baseName, childValueProperty2.baseName);
+        Assert.assertEquals(childModel.vars.get(1).name, childValueProperty2.name);
+        Assert.assertEquals(childModel.vars.get(1).getter, childValueProperty2.getter);
+        Assert.assertEquals(childModel.vars.get(1).setter, childValueProperty2.setter);
     }
 
     public static class P_AbstractJavaCodegen extends AbstractJavaCodegen {


### PR DESCRIPTION
This fixes #936 and #939 to do with how getters and setters are named when the subtype clashes with the parent type.