### PR TITLE
[Python] Lazily initialize thread pool

### DIFF
--- a/src/main/resources/handlebars/python/api_client.mustache
+++ b/src/main/resources/handlebars/python/api_client.mustache
@@ -60,7 +60,7 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
+        self._pool = None  # Use the pool property to lazily initialize the ThreadPool.
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -70,8 +70,15 @@ class ApiClient(object):
         self.user_agent = '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen/{{{packageVersion}}}/python{{/httpUserAgent}}'
 
     def __del__(self):
-        self.pool.close()
-        self.pool.join()
+        if self._pool is not None:
+            self._pool.close()
+            self._pool.join()
+
+    @property
+    def pool(self):
+        if self._pool is None:
+            self._pool = ThreadPool()
+        return self._pool
 
     @property
     def user_agent(self):


### PR DESCRIPTION
Porting a Swagger Codegen 2 fix to Swagger Codegen 3.
The ThreadPool `pool` is only used for async requests.
If a client is not making any async requests, the pool is
initialized and needs to be shutdown regardless. Taking up
resources (threads) and putting a burden on the end user
of the generated client to properly shut down the thread
pool.

https://github.com/swagger-api/swagger-codegen/commit/ebc8313d09cae208b953a8a5ba4742cc7d38d44f#diff-d7b82d024488f96a18a1c76247f1bd57cbde141f28defe6f45b04ce566ab5aeb

Relates to: https://github.com/swagger-api/swagger-codegen/issues/11141