### PR TITLE
Add project lombok and reactor support for MicronautCodegen

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/MicronautCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/MicronautCodegen.java
@@ -2,21 +2,40 @@ package io.swagger.codegen.v3.generators.java;
 
 import com.github.jknack.handlebars.Lambda;
 import com.google.common.collect.ImmutableMap;
-import io.swagger.codegen.v3.*;
+import io.swagger.codegen.v3.CliOption;
+import io.swagger.codegen.v3.CodegenConstants;
+import io.swagger.codegen.v3.CodegenContent;
+import io.swagger.codegen.v3.CodegenModel;
+import io.swagger.codegen.v3.CodegenOperation;
+import io.swagger.codegen.v3.CodegenParameter;
+import io.swagger.codegen.v3.CodegenProperty;
+import io.swagger.codegen.v3.CodegenResponse;
+import io.swagger.codegen.v3.CodegenSecurity;
+import io.swagger.codegen.v3.CodegenType;
+import io.swagger.codegen.v3.SupportingFile;
 import io.swagger.codegen.v3.generators.features.BeanValidationFeatures;
 import io.swagger.codegen.v3.generators.features.OptionalFeatures;
-import io.swagger.codegen.v3.generators.handlebars.lambda.*;
+import io.swagger.codegen.v3.generators.handlebars.lambda.CamelCaseLambda;
+import io.swagger.codegen.v3.generators.handlebars.lambda.CapitaliseLambda;
+import io.swagger.codegen.v3.generators.handlebars.lambda.EscapeDoubleQuotesLambda;
+import io.swagger.codegen.v3.generators.handlebars.lambda.IndentedLambda;
+import io.swagger.codegen.v3.generators.handlebars.lambda.LowercaseLambda;
+import io.swagger.codegen.v3.generators.handlebars.lambda.RemoveLineBreakLambda;
+import io.swagger.codegen.v3.generators.handlebars.lambda.TitlecaseLambda;
+import io.swagger.codegen.v3.generators.handlebars.lambda.UppercaseLambda;
 import io.swagger.codegen.v3.utils.URLPathUtil;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static io.swagger.codegen.v3.CodegenConstants.HAS_ENUMS_EXT_NAME;
@@ -36,6 +55,8 @@ public class MicronautCodegen extends AbstractJavaCodegen implements BeanValidat
     private static final String USE_TAGS = "useTags";
     private static final String IMPLICIT_HEADERS = "implicitHeaders";
     private static final String SKIP_SUPPORT_FILES = "skipSupportFiles";
+    private static final String USE_LOMBOK_MODEL = "useLombokModel";
+    private static final String USE_PROJECT_REACTOR = "useProjectReactor";
 
     private String title = "swagger-petstore";
     private String configPackage = "io.swagger.configuration";
@@ -44,6 +65,8 @@ public class MicronautCodegen extends AbstractJavaCodegen implements BeanValidat
     private boolean useBeanValidation = true;
     private boolean implicitHeaders = false;
     private boolean useOptional = false;
+    private boolean useLombokModel=false;
+    private boolean useProjectReactor=false;
 
     @SuppressWarnings("unused")
     public MicronautCodegen() {
@@ -73,6 +96,10 @@ public class MicronautCodegen extends AbstractJavaCodegen implements BeanValidat
         cliOptions.add(CliOption.newBoolean(IMPLICIT_HEADERS, "Use of @ApiImplicitParams for headers."));
         cliOptions.add(CliOption.newBoolean(USE_OPTIONAL,
                 "Use Optional container for optional parameters"));
+        cliOptions.add(CliOption.newBoolean(USE_LOMBOK_MODEL,
+            "Use lombok for the pojo generation. It comes with @AllArgsConstructor, @EqualsAndHashCode, @ToString, @Getter, @Builder and @NonNull on required fields"));
+        cliOptions.add(CliOption.newBoolean(USE_PROJECT_REACTOR,
+            "Use Project Reactor instead of RxJava"));
 
         supportedLibraries.put(DEFAULT_LIBRARY, "Java Micronaut Server application.");
         setLibrary(DEFAULT_LIBRARY);
@@ -150,6 +177,14 @@ public class MicronautCodegen extends AbstractJavaCodegen implements BeanValidat
             this.setUseOptional(convertPropertyToBoolean(USE_OPTIONAL));
         }
 
+        if (additionalProperties.containsKey(USE_LOMBOK_MODEL)) {
+            this.setUseLombokModel(convertPropertyToBoolean(USE_LOMBOK_MODEL));
+        }
+
+        if (additionalProperties.containsKey(USE_PROJECT_REACTOR)) {
+            this.setUseProjectReactor(convertPropertyToBoolean(USE_PROJECT_REACTOR));
+        }
+
         boolean skipSupportFiles = false;
         if (additionalProperties.containsKey(SKIP_SUPPORT_FILES)) {
             skipSupportFiles = Boolean.valueOf(additionalProperties.get(SKIP_SUPPORT_FILES).toString());
@@ -165,6 +200,14 @@ public class MicronautCodegen extends AbstractJavaCodegen implements BeanValidat
 
         if (useOptional) {
             writePropertyBack(USE_OPTIONAL, useOptional);
+        }
+
+        if (useLombokModel) {
+            writePropertyBack(USE_LOMBOK_MODEL, useLombokModel);
+        }
+
+        if (useProjectReactor) {
+            writePropertyBack(USE_PROJECT_REACTOR, useProjectReactor);
         }
 
         if (!skipSupportFiles) {
@@ -528,5 +571,13 @@ public class MicronautCodegen extends AbstractJavaCodegen implements BeanValidat
     @Override
     public void setUseOptional(boolean useOptional) {
         this.useOptional = useOptional;
+    }
+
+    public void setUseLombokModel(boolean useLombokModel) {
+        this.useLombokModel = useLombokModel;
+    }
+
+    public void setUseProjectReactor(boolean useProjectReactor) {
+        this.useProjectReactor = useProjectReactor;
     }
 }

--- a/src/main/resources/handlebars/JavaMicronaut/api.mustache
+++ b/src/main/resources/handlebars/JavaMicronaut/api.mustache
@@ -10,7 +10,12 @@ package {{package}};
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micronaut.http.*;
 import io.micronaut.http.annotation.*;
+{{#useProjectReactor}}
+import reactor.core.publisher.Mono;
+{{/useProjectReactor}}
+{{^useProjectReactor}}
 import io.reactivex.Single;
+{{/useProjectReactor}}
 import io.swagger.v3.oas.annotations.*;
 import io.swagger.v3.oas.annotations.responses.*;
 import org.slf4j.Logger;
@@ -46,11 +51,20 @@ public interface {{classname}} {
     })
     {{/implicitHeaders}}
     @{{#lambda.capitalise}}{{httpMethod}}{{/lambda.capitalise}}(value = "{{{path}}}"{{#hasProduces}}, produces = { {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }{{/hasProduces}}{{#hasConsumes}}, consumes = {{braces "left"}}{{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}}{{braces "right"}}{{/hasConsumes}})
-    default Single<HttpResponse<{{>returnTypes}}>> {{operationId}}({{#parameters}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/parameters}}) {
-        return Single.fromCallable(() -> {
-            throw new UnsupportedOperationException();
+    {{#useProjectReactor}}
+        default Mono<HttpResponse<{{>returnTypes}}>> {{operationId}}({{#parameters}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/parameters}}) {
+        return Mono.fromCallable(() -> {
+        throw new UnsupportedOperationException();
         });
-    }
+        }
+    {{/useProjectReactor}}
+    {{^useProjectReactor}}
+        default Single<HttpResponse<{{>returnTypes}}>> {{operationId}}({{#parameters}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/parameters}}) {
+        return Single.fromCallable(() -> {
+        throw new UnsupportedOperationException();
+        });
+        }
+    {{/useProjectReactor}}
 
 {{/contents}}
 {{/operation}}

--- a/src/main/resources/handlebars/JavaMicronaut/beanValidation.mustache
+++ b/src/main/resources/handlebars/JavaMicronaut/beanValidation.mustache
@@ -1,6 +1,9 @@
+{{^useLombokModel}}
 {{#required}}
-  @NotNull
-{{/required}}{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}
+@NotNull
+{{/required}}
+{{/useLombokModel}}
+{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}
   @Valid{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{#isNotContainer}}{{^isPrimitiveType}}
   @Valid{{/isPrimitiveType}}{{/isNotContainer}}
 {{>beanValidationCore}}

--- a/src/main/resources/handlebars/JavaMicronaut/model.mustache
+++ b/src/main/resources/handlebars/JavaMicronaut/model.mustache
@@ -11,6 +11,14 @@ import io.micronaut.validation.Validated;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 {{/useBeanValidation}}
+{{#useLombokModel}}
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+{{/useLombokModel}}
 {{#jackson}}
 {{#withXml}}
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;

--- a/src/main/resources/handlebars/JavaMicronaut/pojo.mustache
+++ b/src/main/resources/handlebars/JavaMicronaut/pojo.mustache
@@ -2,6 +2,13 @@
  * {{#description}}{{.}}{{/description}}{{^description}}{{classname}}{{/description}}
  */{{#description}}
 @Schema(description = "{{{description}}}"){{/description}}
+{{#useLombokModel}}
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Getter
+@Builder
+{{/useLombokModel}}
 {{#useBeanValidation}}@Validated{{/useBeanValidation}}
 {{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
@@ -22,6 +29,21 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{#gson}}
   @SerializedName("{{baseName}}")
   {{/gson}}
+  {{#useLombokModel}}
+  {{#required}}@NonNull{{/required}}
+  {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}
+
+  {{#isContainer}}
+  {{#useBeanValidation}}@Valid{{/useBeanValidation}}
+  private {{{datatypeWithEnum}}} {{name}}{{#required}} = {{{defaultValue}}}{{/required}};
+
+  {{/isContainer}}
+  {{^isContainer}}
+  private {{{datatypeWithEnum}}} {{name}};
+
+  {{/isContainer}}
+  {{/useLombokModel}}
+  {{^useLombokModel}}
   {{#isContainer}}
   {{#useBeanValidation}}@Valid{{/useBeanValidation}}
   private {{{datatypeWithEnum}}} {{name}}{{#required}} = {{{defaultValue}}}{{/required}}{{^required}} = null{{/required}};
@@ -29,8 +51,9 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{^isContainer}}
   private {{{datatypeWithEnum}}} {{name}} = {{{defaultValue}}};
   {{/isContainer}}
-
+  {{/useLombokModel}}
   {{/vars}}
+  {{^useLombokModel}}
   {{#vars}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
@@ -130,4 +153,5 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     }
     return o.toString().replace("\n", "\n    ");
   }
+{{/useLombokModel}}
 }

--- a/src/main/resources/handlebars/JavaMicronaut/pom.mustache
+++ b/src/main/resources/handlebars/JavaMicronaut/pom.mustache
@@ -4,7 +4,7 @@
     <artifactId>{{artifactId}}</artifactId>
     <version>{{artifactVersion}}</version>
     <properties>
-        <micronaut.version>1.1.4</micronaut.version>
+        <micronaut.version>3.0.0</micronaut.version>
         <jdk.version>1.8</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <exec.mainClass>{{basePackage}}.MainApplication</exec.mainClass>
@@ -155,7 +155,7 @@
                             <path>
                                 <groupId>io.micronaut.configuration</groupId>
                                 <artifactId>micronaut-openapi</artifactId>
-                                <version>1.1.1</version>
+                                <version>3.0.1</version>
                             </path>
                         </annotationProcessorPaths>
                     </configuration>
@@ -183,7 +183,7 @@
                                     <path>
                                         <groupId>io.micronaut.configuration</groupId>
                                         <artifactId>micronaut-openapi</artifactId>
-                                        <version>1.1.1</version>
+                                        <version>3.0.1</version>
                                     </path>
                                 </annotationProcessorPaths>
                             </configuration>


### PR DESCRIPTION
The current codegen for java - micronaut supports only RxJava in Api as Single .
Micronaut also supports project reactor and the latest version 3.0.0 does not come default framework.

Added support for Project Reactor, by adding a new flag **useProjectReactor**, its gives consumers flexibility to choose between project reactor and RxJava.

Also added support for Project Lombok.
This also works based on a new flag **useLombokModel** .

By default flags are set false , so that they do not have impact existing consumers.

Also upgrade the micronaut version and micronaut open-api versions to the latest