### PR TITLE
feat: use default default rxjava3 adapter for retrofit2

### DIFF
--- a/src/main/resources/handlebars/Java/libraries/retrofit2/ApiClient.mustache
+++ b/src/main/resources/handlebars/Java/libraries/retrofit2/ApiClient.mustache
@@ -24,7 +24,7 @@ import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 {{/useRxJava2}}
 {{#useRxJava3}}
-import hu.akarnokd.rxjava3.retrofit.RxJava3CallAdapterFactory;
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory;
 {{/useRxJava3}}
 import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
@@ -146,7 +146,7 @@ public class ApiClient {
       {{/useRxJava}}{{#useRxJava2}}
       .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
       {{/useRxJava2}}{{#useRxJava3}}
-      .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
+      .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
       {{/useRxJava3}}
       .addConverterFactory(ScalarsConverterFactory.create())
       .addConverterFactory(GsonCustomConverterFactory.create(json.getGson()));

--- a/src/main/resources/handlebars/Java/libraries/retrofit2/pom.mustache
+++ b/src/main/resources/handlebars/Java/libraries/retrofit2/pom.mustache
@@ -263,16 +263,16 @@
     </dependency>
     {{/useRxJava2}}
     {{#useRxJava3}}
-      <dependency>
-          <groupId>io.reactivex.rxjava3</groupId>
-          <artifactId>rxjava</artifactId>
-          <version>${rxjava-version}</version>
-      </dependency>
-      <dependency>
-          <groupId>com.github.akarnokd</groupId>
-          <artifactId>rxjava3-retrofit-adapter</artifactId>
-          <version>3.0.0</version>
-      </dependency>
+    <dependency>
+      <groupId>io.reactivex.rxjava3</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>${rxjava-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.retrofit2</groupId>
+      <artifactId>adapter-rxjava3</artifactId>
+      <version>${retrofit-version}</version>
+    </dependency>
     {{/useRxJava3}}
 
     {{#usePlayWS}}
@@ -318,7 +318,7 @@
         <version>${play-version}</version>
     </dependency>
     {{/usePlayWS}}
-    
+
     {{#parcelableModel}}
     <!-- Needed for Parcelable support-->
     <dependency>


### PR DESCRIPTION
When adding support of RxJava3 for Retrofit2 generator, adapter used was a third party library: https://github.com/swagger-api/swagger-codegen/issues/10312

An "official" adapter is provided by squareup itself which follows the versioning of retrofit2. It's probably a better choice to stick to default implementation.

Previously, RxJava3CallAdapterFactory.create() was returning an adapter which was creating synchronous Observables by default. Now, RxJava3CallAdapterFactory.create() returns an adapter which create async Observables by default, that's why I keep previous behaviour, however, maybe we should stick to default behaviour desired by squareup.