### PR TITLE
Git repo Base URL config option

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -160,7 +160,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
     protected Boolean sortParamsByRequiredFlag = true;
     protected Boolean ensureUniqueParams = true;
     protected Boolean allowUnicodeIdentifiers = false;
-    protected String gitUserId, gitRepoId, releaseNote;
+    protected String gitUserId, gitRepoId, releaseNote, gitRepoBaseURL;
     protected String httpUserAgent;
     protected Boolean hideGenerationTimestamp = true;
     protected TemplateEngine templateEngine = new HandlebarTemplateEngine(this);
@@ -3561,6 +3561,26 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
     public String getGitRepoId() {
         return gitRepoId;
     }
+
+
+    /**
+     * Git repo Base URL
+     *
+     * @return Git repo Base URL
+     */
+    public String getGitRepoBaseURL() {
+        return gitRepoBaseURL;
+    }
+
+    /**
+     * Set Git repo Base URL.
+     *
+     * @param gitRepoBaseURL Git repo Base URL
+     */
+    public void setGitRepoBaseURL(String gitRepoBaseURL) {
+        this.gitRepoBaseURL = gitRepoBaseURL;
+    }
+
 
     /**
      * Set release note.

--- a/src/main/java/io/swagger/codegen/v3/generators/php/AbstractPhpCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/php/AbstractPhpCodegen.java
@@ -251,7 +251,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegenConfig {
     }
 
    @Override
-    public String escapeReservedWord(String name) {           
+    public String escapeReservedWord(String name) {
         if(this.reservedWordsMappings().containsKey(name)) {
             return this.reservedWordsMappings().get(name);
         }

--- a/src/main/java/io/swagger/codegen/v3/generators/php/PhpClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/php/PhpClientCodegen.java
@@ -110,8 +110,7 @@ public class PhpClientCodegen extends DefaultCodegenConfig {
 
         instantiationTypes.put("array", "array");
         instantiationTypes.put("map", "map");
-
-
+        
         // provide primitives to mustache template
         List<String> sortedLanguageSpecificPrimitives= new ArrayList<String>(languageSpecificPrimitives);
         Collections.sort(sortedLanguageSpecificPrimitives);
@@ -152,6 +151,7 @@ public class PhpClientCodegen extends DefaultCodegenConfig {
         cliOptions.add(new CliOption(CodegenConstants.GIT_USER_ID, CodegenConstants.GIT_USER_ID_DESC));
         cliOptions.add(new CliOption(COMPOSER_PROJECT_NAME, "The project name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. petstore-client. IMPORTANT NOTE (2016/03): composerProjectName will be deprecated and replaced by gitRepoId in the next swagger-codegen release"));
         cliOptions.add(new CliOption(CodegenConstants.GIT_REPO_ID, CodegenConstants.GIT_REPO_ID_DESC));
+        cliOptions.add(new CliOption(CodegenConstants.GIT_REPO_BASE_URL, CodegenConstants.GIT_REPO_BASE_URL_DESC));
         cliOptions.add(new CliOption(CodegenConstants.ARTIFACT_VERSION, "The version to use in the composer package version field. e.g. 1.2.3"));
         cliOptions.add(new CliOption(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "hides the timestamp when files were generated")
                 .defaultValue(Boolean.TRUE.toString()));
@@ -278,6 +278,12 @@ public class PhpClientCodegen extends DefaultCodegenConfig {
             this.setGitRepoId((String) additionalProperties.get(CodegenConstants.GIT_REPO_ID));
         } else {
             additionalProperties.put(CodegenConstants.GIT_REPO_ID, gitRepoId);
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.GIT_REPO_BASE_URL)) {
+            this.setGitRepoBaseURL((String) additionalProperties.get(CodegenConstants.GIT_REPO_BASE_URL));
+        } else {
+            additionalProperties.put(CodegenConstants.GIT_REPO_BASE_URL, gitRepoBaseURL);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.ARTIFACT_VERSION)) {

--- a/src/main/resources/handlebars/php/README.mustache
+++ b/src/main/resources/handlebars/php/README.mustache
@@ -31,7 +31,7 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
   "repositories": [
     {
       "type": "git",
-      "url": "https://github.com/{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}.git"
+      "url": "http://{{gitRepoBaseURL}}.com/{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}.git"
     }
   ],
   "require": {

--- a/src/main/resources/handlebars/php/git_push.sh.mustache
+++ b/src/main/resources/handlebars/php/git_push.sh.mustache
@@ -37,9 +37,9 @@ if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
         echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
+        git remote add origin https://${git_repo_base_url}.com/${git_user_id}/${git_repo_id}.git
     else
-        git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git
+        git remote add origin https://${git_user_id}:${GIT_TOKEN}@${git_repo_base_url}.com/${git_user_id}/${git_repo_id}.git
     fi
 
 fi
@@ -47,6 +47,6 @@ fi
 git pull origin master
 
 # Pushes (Forces) the changes in the local repository up to the remote repository
-echo "Git pushing to https://github.com/${git_user_id}/${git_repo_id}.git"
+echo "Git pushing to https://${git_repo_base_url}.com/${git_user_id}/${git_repo_id}.git"
 git push origin master 2>&1 | grep -v 'To https'
 


### PR DESCRIPTION
This pr creates an option to allow the configuration of the repo base url in the readme and git_push.sh files in php generator.
Option name: gitRepoBaseURL("string of repo url");
depends on: https://github.com/swagger-api/swagger-codegen/pull/11175