### PR TITLE
[Ruby] Bugfixe datatype when generating model

### DIFF
--- a/src/main/resources/handlebars/ruby/partial_model_generic.mustache
+++ b/src/main/resources/handlebars/ruby/partial_model_generic.mustache
@@ -46,7 +46,7 @@
     def self.openapi_types
       {
         {{#vars}}
-        :'{{{name}}}' => :'{{{dataType}}}'{{#hasMore}},{{/hasMore}}
+        :'{{{name}}}' => :'{{{datatype}}}'{{#hasMore}},{{/hasMore}}
         {{/vars}}
       }
     end
@@ -183,7 +183,7 @@
       {{/required}}
       {{#isEnum}}
       {{^isContainer}}
-      {{{name}}}_validator = EnumAttributeValidator.new('{{{dataType}}}', [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^@last}}, {{/@last}}{{/enumVars}}{{/allowableValues}}])
+      {{{name}}}_validator = EnumAttributeValidator.new('{{{datatype}}}', [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^@last}}, {{/@last}}{{/enumVars}}{{/allowableValues}}])
       return false unless {{{name}}}_validator.valid?(@{{{name}}})
       {{/isContainer}}
       {{/isEnum}}
@@ -220,7 +220,7 @@
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] {{{name}}} Object to be assigned
     def {{{name}}}=({{{name}}})
-      validator = EnumAttributeValidator.new('{{{dataType}}}', [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^@last}}, {{/@last}}{{/enumVars}}{{/allowableValues}}])
+      validator = EnumAttributeValidator.new('{{{datatype}}}', [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^@last}}, {{/@last}}{{/enumVars}}{{/allowableValues}}])
       unless validator.valid?({{{name}}})
         fail ArgumentError, "invalid value for \"{{{name}}}\", must be one of #{validator.allowable_values}."
       end


### PR DESCRIPTION
While generating Ruby clients, I noticed that the type was always being generated as a plan `Object` despite my schema having correctly specified schemas for my types. Upon investigation, I found that the property in the models list which is passed to the HandlebarsEngine is `datatype`. The handlebars template is currently using `dataType`, resulting on the fallback `Object` to be used instead. 

![image](https://user-images.githubusercontent.com/6290908/133896392-edb957a9-1ebf-428b-ada7-616eea84da42.png)

Before change:
```ruby  
# Attribute type mapping.
    def self.openapi_types
      {
        :'request' => :'Object'
      }
    end
...
```

After change:
```ruby
    # Attribute type mapping.
    def self.openapi_types
      {
        :'request' => :'Request'
      }
    end
...
```

schema.yaml
```yaml
    RequestPayload:
      type: object
      required:
        - request
      properties:
        request:
          $ref: "#/components/schemas/Request"
    Request:
      type: object
      required:
        - patient
        - prescription
        - state
        - form_id
      properties:
...
```
