### PR TITLE
Fix the compile error caused by \n at request body description

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -2657,7 +2657,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         }
         codegenParameter.baseName = bodyName;
         codegenParameter.paramName = bodyName;
-        codegenParameter.description = body.getDescription();
+        codegenParameter.description = escapeText(body.getDescription());
         codegenParameter.unescapedDescription = body.getDescription();
         codegenParameter.required = body.getRequired() != null ? body.getRequired() : Boolean.FALSE;
         codegenParameter.getVendorExtensions().put(CodegenConstants.IS_BODY_PARAM_EXT_NAME, Boolean.TRUE);


### PR DESCRIPTION
fixed swagger-api/swagger-codegen#11300

When there was \n at the request body description, the result code had compile error. Because template engine write every \n on separate line. so \n s must have removed from the text as it had at response  description (response message).
By using  escapeText method  when setting description, this problem solved. 