### PR TITLE
[FIX][PHP] hydra model properties with @ prefix results in invalid classes because of incorrect sanitization

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -3666,6 +3666,42 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         return name;
     }
 
+    /**
+     * Sanitize name (parameter, property, method, etc)
+     *
+     * @param name string to be sanitize
+     * @return sanitized string
+     */
+    @SuppressWarnings("static-method")
+    public String sanitizeVarName(String name) {
+        if (name == null) {
+            LOGGER.warn("String to be sanitized is null. Default to " + Object.class.getSimpleName());
+            return Object.class.getSimpleName();
+        }
+        if ("$".equals(name)) {
+            return "value";
+        }
+        name = name.replaceAll("\\[\\]", StringUtils.EMPTY);
+        name = name.replaceAll("\\[", "_")
+            .replaceAll("\\]", "")
+            .replaceAll("\\(", "_")
+            .replaceAll("\\)", StringUtils.EMPTY)
+            .replaceAll("\\.", "_")
+            .replaceAll("@", "_at_")
+            .replaceAll("-", "_")
+            .replaceAll(" ", "_");
+
+        // remove everything else other than word, number and _
+        // $php_variable => php_variable
+        if (allowUnicodeIdentifiers) { //could be converted to a single line with ?: operator
+            name = Pattern.compile("[\\W&&[^$]]", Pattern.UNICODE_CHARACTER_CLASS).matcher(name).replaceAll(StringUtils.EMPTY);
+        }
+        else {
+            name = name.replaceAll("[\\W&&[^$]]", StringUtils.EMPTY);
+        }
+        return name;
+    }
+
     private boolean maybeHandleDollarName(String name) {
         if ("$".equals(name)) {
             return true;

--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -1326,35 +1326,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         return op;
     }
 
-    public String sanitizeVarName(String name) {
-        if (name == null) {
-            LOGGER.warn("String to be sanitized is null. Default to " + Object.class.getSimpleName());
-            return Object.class.getSimpleName();
-        }
-        if ("$".equals(name)) {
-            return "value";
-        }
-        name = name.replaceAll("\\[\\]", StringUtils.EMPTY);
-        name = name.replaceAll("\\[", "_")
-                .replaceAll("\\]", "")
-                .replaceAll("\\(", "_")
-                .replaceAll("\\)", StringUtils.EMPTY)
-                .replaceAll("\\.", "_")
-                .replaceAll("@", "_at_")
-                .replaceAll("-", "_")
-                .replaceAll(" ", "_");
-
-        // remove everything else other than word, number and _
-        // $php_variable => php_variable
-        if (allowUnicodeIdentifiers) { //could be converted to a single line with ?: operator
-            name = Pattern.compile("[\\W&&[^$]]", Pattern.UNICODE_CHARACTER_CLASS).matcher(name).replaceAll(StringUtils.EMPTY);
-        }
-        else {
-            name = name.replaceAll("[\\W&&[^$]]", StringUtils.EMPTY);
-        }
-        return name;
-    }
-
     private static CodegenModel reconcileInlineEnums(CodegenModel codegenModel, CodegenModel parentCodegenModel) {
         // This generator uses inline classes to define enums, which breaks when
         // dealing with models that have subTypes. To clean this up, we will analyze

--- a/src/main/java/io/swagger/codegen/v3/generators/php/AbstractPhpCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/php/AbstractPhpCodegen.java
@@ -383,7 +383,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegenConfig {
     @Override
     public String toVarName(String name) {
         // sanitize name
-        name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
+        name = sanitizeVarName(name);
 
         if ("camelCase".equals(variableNamingConvention)) {
           // return the name in camelCase style

--- a/src/main/java/io/swagger/codegen/v3/generators/php/PhpClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/php/PhpClientCodegen.java
@@ -110,7 +110,7 @@ public class PhpClientCodegen extends DefaultCodegenConfig {
 
         instantiationTypes.put("array", "array");
         instantiationTypes.put("map", "map");
-        
+
         // provide primitives to mustache template
         List<String> sortedLanguageSpecificPrimitives= new ArrayList<String>(languageSpecificPrimitives);
         Collections.sort(sortedLanguageSpecificPrimitives);
@@ -467,7 +467,7 @@ public class PhpClientCodegen extends DefaultCodegenConfig {
     @Override
     public String toVarName(String name) {
         // sanitize name
-        name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
+        name = sanitizeVarName(name);
 
         if ("camelCase".equals(variableNamingConvention)) {
           // return the name in camelCase style

--- a/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegenTest.java
@@ -102,6 +102,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(fakeJavaCodegen.toVarName("name"), "name");
         Assert.assertEquals(fakeJavaCodegen.toVarName("$name"), "$name");
         Assert.assertEquals(fakeJavaCodegen.toVarName("nam$$e"), "nam$$e");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("@type"), "_atType");
         Assert.assertEquals(fakeJavaCodegen.toVarName("_name"), "_name");
         Assert.assertEquals(fakeJavaCodegen.toVarName("user-name"), "userName");
         Assert.assertEquals(fakeJavaCodegen.toVarName("user_name"), "userName");

--- a/src/test/java/io/swagger/codegen/v3/generators/php/PhpClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/php/PhpClientCodegenTest.java
@@ -78,4 +78,20 @@ public class PhpClientCodegenTest {
         Assert.assertEquals(codegen.customTemplateDir(), "/absolute/path");
         Assert.assertEquals(codegen.embeddedTemplateDir(), "handlebars" + File.separator + "php");
     }
+
+    @Test(description = "test variable names for reserved characters and word")
+    public void testVarName() throws Exception {
+        final PhpClientCodegen codegen = new PhpClientCodegen();
+        Assert.assertEquals(codegen.toVarName("@id"), "_at_id");
+        Assert.assertEquals(codegen.toVarName("@type"), "_at_type");
+        Assert.assertEquals(codegen.toVarName("@context"), "_at_context");
+        Assert.assertEquals(codegen.toVarName("$someDollar"), "__some_dollar");
+        Assert.assertEquals(codegen.toVarName("!notThis"), "not_this");
+
+        // allow starting with underscore
+        Assert.assertEquals(codegen.toVarName("_allowUnderscore"), "_allow_underscore");
+
+        // should not escape non-reserved
+        Assert.assertEquals(codegen.toVarName("hello"), "hello");
+    }
 }


### PR DESCRIPTION
Fixes issue: https://github.com/swagger-api/swagger-codegen-generators/issues/1041 where we would get invalid PHP classes because of duplicate var names and resulting duplicate methods. 

I believe the Java generator already solved their issue with their method sanitizeVarName, see test in [AbstractJavaCodegenTest.java](https://github.com/swagger-api/swagger-codegen-generators/compare/master...warmwaterkruik:sanitize-var-name?expand=1#diff-00dd9acf06909c371fd318e7e502b111ba46319abc1da7386b984d6a85a4414f) 

Thus I moved their helper method into the DefaultCodegenConfig.java class and called it from PHP [PhpClientCodegen.java](https://github.com/swagger-api/swagger-codegen-generators/compare/master...warmwaterkruik:sanitize-var-name?expand=1#diff-68387fbdcc039bf3610adf643346397e5eede44aaebda4037fa20c8016a3877b) 

I suspect other languages would benefit from using the helper sanitizeVarName instead of sanitizeName. 