### PR TITLE
Added missing property for returnResponse. Also added returnResponseO…

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaJAXRSServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaJAXRSServerCodegen.java
@@ -37,6 +37,8 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
     protected String testResourcesFolder = "src/test/resources";
     protected String title = "Swagger Server";
 
+    public static final String RETURN_RESPONSE_OVER_VOID = "returnResponseOverVoid";
+    protected boolean returnResponseOverVoid = false;
     protected boolean useBeanValidation = true;
 
     public AbstractJavaJAXRSServerCodegen() {
@@ -59,6 +61,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
 
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations"));
         cliOptions.add(new CliOption("serverPort", "The port on which the server should be started"));
+        cliOptions.add(CliOption.newBoolean(RETURN_RESPONSE_OVER_VOID, "Whether to return a javax.ws.rs.core.Response instead of void.").defaultValue(String.valueOf(returnResponseOverVoid)));
     }
 
 
@@ -86,7 +89,9 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         if (useBeanValidation) {
             writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
         }
-
+        if (additionalProperties.containsKey(RETURN_RESPONSE_OVER_VOID)) {
+        	returnResponseOverVoid = Boolean.valueOf(additionalProperties.get(RETURN_RESPONSE_OVER_VOID).toString());
+        } 
     }
 
     @Override
@@ -131,6 +136,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
 
     @Override
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
+    	objs.put(RETURN_RESPONSE_OVER_VOID, returnResponseOverVoid);
         return jaxrsPostProcessOperations(objs);
     }
 
@@ -170,6 +176,12 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
                     }
                 }
 
+                String defaultDataType = "void";
+                
+                if(objs.get(RETURN_RESPONSE_OVER_VOID)!=null && Boolean.parseBoolean(objs.get(RETURN_RESPONSE_OVER_VOID).toString())) {
+                	defaultDataType = "Response";
+                }
+                
                 List<CodegenResponse> responses = operation.responses;
                 if ( responses != null ) {
                     for ( CodegenResponse resp : responses ) {
@@ -178,7 +190,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
                         }
 
                         if (resp.baseType == null) {
-                            resp.dataType = "void";
+                            resp.dataType = defaultDataType;
                             resp.baseType = "Void";
                             // set vendorExtensions.x-java-is-response-void to true as baseType is set to "Void"
                             resp.vendorExtensions.put("x-java-is-response-void", true);
@@ -193,7 +205,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
                 }
 
                 if ( operation.returnBaseType == null ) {
-                    operation.returnType = "void";
+                    operation.returnType = defaultDataType;
                     operation.returnBaseType = "Void";
                     // set vendorExtensions.x-java-is-response-void to true as returnBaseType is set to "Void"
                     operation.vendorExtensions.put("x-java-is-response-void", true);

--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaJAXRSServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaJAXRSServerCodegen.java
@@ -90,7 +90,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
             writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
         }
         if (additionalProperties.containsKey(RETURN_RESPONSE_OVER_VOID)) {
-        	returnResponseOverVoid = Boolean.valueOf(additionalProperties.get(RETURN_RESPONSE_OVER_VOID).toString());
+            returnResponseOverVoid = Boolean.valueOf(additionalProperties.get(RETURN_RESPONSE_OVER_VOID).toString());
         } 
     }
 
@@ -136,7 +136,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
 
     @Override
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
-    	objs.put(RETURN_RESPONSE_OVER_VOID, returnResponseOverVoid);
+        objs.put(RETURN_RESPONSE_OVER_VOID, returnResponseOverVoid);
         return jaxrsPostProcessOperations(objs);
     }
 
@@ -179,7 +179,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
                 String defaultDataType = "void";
                 
                 if(objs.get(RETURN_RESPONSE_OVER_VOID)!=null && Boolean.parseBoolean(objs.get(RETURN_RESPONSE_OVER_VOID).toString())) {
-                	defaultDataType = "Response";
+                    defaultDataType = "Response";
                 }
                 
                 List<CodegenResponse> responses = operation.responses;

--- a/src/main/java/io/swagger/codegen/v3/generators/java/JavaJAXRSSpecServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/JavaJAXRSSpecServerCodegen.java
@@ -72,7 +72,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
             interfaceOnly = Boolean.valueOf(additionalProperties.get(INTERFACE_ONLY).toString());
         }
         if (additionalProperties.containsKey(RETURN_RESPONSE)) {
-        	returnResponse = Boolean.valueOf(additionalProperties.get(RETURN_RESPONSE).toString());
+            returnResponse = Boolean.valueOf(additionalProperties.get(RETURN_RESPONSE).toString());
         }
         
         if (interfaceOnly) {

--- a/src/main/java/io/swagger/codegen/v3/generators/java/JavaJAXRSSpecServerCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/JavaJAXRSSpecServerCodegen.java
@@ -23,9 +23,12 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
 
     public static final String INTERFACE_ONLY = "interfaceOnly";
     public static final String GENERATE_POM = "generatePom";
+    public static final String RETURN_RESPONSE = "returnResponse";
+    
 
     private boolean interfaceOnly = false;
     private boolean generatePom = true;
+    protected boolean returnResponse = false;
 
     public JavaJAXRSSpecServerCodegen() {
         super();
@@ -57,6 +60,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         cliOptions.add(library);
         cliOptions.add(CliOption.newBoolean(GENERATE_POM, "Whether to generate pom.xml if the file does not already exist.").defaultValue(String.valueOf(generatePom)));
         cliOptions.add(CliOption.newBoolean(INTERFACE_ONLY, "Whether to generate only API interface stubs without the server files.").defaultValue(String.valueOf(interfaceOnly)));
+        cliOptions.add(CliOption.newBoolean(RETURN_RESPONSE, "Whether to return a javax.ws.rs.core.Response.").defaultValue(String.valueOf(returnResponse)));
     }
 
     @Override
@@ -67,6 +71,10 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         if (additionalProperties.containsKey(INTERFACE_ONLY)) {
             interfaceOnly = Boolean.valueOf(additionalProperties.get(INTERFACE_ONLY).toString());
         }
+        if (additionalProperties.containsKey(RETURN_RESPONSE)) {
+        	returnResponse = Boolean.valueOf(additionalProperties.get(RETURN_RESPONSE).toString());
+        }
+        
         if (interfaceOnly) {
             // Change default artifactId if genereating interfaces only, before
             // command line options are applied in base class.

--- a/src/test/java/io/swagger/codegen/v3/generators/java/JaxRsSpecReturnResponseOverVoidTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/JaxRsSpecReturnResponseOverVoidTest.java
@@ -1,0 +1,42 @@
+package io.swagger.codegen.v3.generators.java;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.rules.TemporaryFolder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.swagger.codegen.v3.ClientOptInput;
+import io.swagger.codegen.v3.DefaultGenerator;
+import io.swagger.codegen.v3.config.CodegenConfigurator;
+
+public class JaxRsSpecReturnResponseOverVoidTest {
+	 private TemporaryFolder folder = new TemporaryFolder();
+	 
+	    @Test
+	    public void returnResponseOverVoid() throws Exception {
+	        folder.create();
+	        final File output = folder.getRoot();
+
+	        Map<String, Object> additionalProperties = new HashMap<String, Object>();
+	        additionalProperties.put(AbstractJavaJAXRSServerCodegen.RETURN_RESPONSE_OVER_VOID, true);
+	        additionalProperties.put(JavaJAXRSSpecServerCodegen.INTERFACE_ONLY, true);
+	        final CodegenConfigurator configurator = new CodegenConfigurator()
+	                .setLang("jaxrs-spec").setAdditionalProperties(additionalProperties)
+	                .setInputSpecURL("src/test/resources/3_0_0/petstore.yaml")
+	                .setOutputDir(output.getAbsolutePath());
+
+	        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+	        new DefaultGenerator().opts(clientOptInput).generate();
+
+	        File petFile = new File(output, "src/gen/java/io/swagger/api/PetApi.java");
+	        final String content = FileUtils.readFileToString(petFile);
+	        
+	        Assert.assertTrue(content.contains("Response addPet"));
+	        Assert.assertTrue(content.contains("Pet getPetById"));
+	        folder.delete();
+	    }
+}

--- a/src/test/java/io/swagger/codegen/v3/generators/java/JaxRsSpecReturnResponseTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/JaxRsSpecReturnResponseTest.java
@@ -1,0 +1,41 @@
+package io.swagger.codegen.v3.generators.java;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.rules.TemporaryFolder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.swagger.codegen.v3.ClientOptInput;
+import io.swagger.codegen.v3.DefaultGenerator;
+import io.swagger.codegen.v3.config.CodegenConfigurator;
+
+public class JaxRsSpecReturnResponseTest {
+    private TemporaryFolder folder = new TemporaryFolder();
+    
+    @Test
+    public void returnResponse() throws Exception {
+        folder.create();
+        final File output = folder.getRoot();
+
+        Map<String, Object> additionalProperties = new HashMap<String, Object>();
+        additionalProperties.put(JavaJAXRSSpecServerCodegen.RETURN_RESPONSE, true);
+        additionalProperties.put(JavaJAXRSSpecServerCodegen.INTERFACE_ONLY, true);
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setLang("jaxrs-spec").setAdditionalProperties(additionalProperties)
+                .setInputSpecURL("src/test/resources/3_0_0/petstore.yaml")
+                .setOutputDir(output.getAbsolutePath());
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        new DefaultGenerator().opts(clientOptInput).generate();
+
+        File petFile = new File(output, "src/gen/java/io/swagger/api/PetApi.java");
+        final String content = FileUtils.readFileToString(petFile);
+        
+        Assert.assertTrue(content.contains("Response ")); 
+        folder.delete();
+    }
+}


### PR DESCRIPTION
…verVoid

Added in support for the additional property returnResponse - so the option in src/main/resources/handlebars/JavaJaxRS/spec/apiInterface.mustache is now honoured. 

Also, added in the additional property returnResponseOverVoid - which causes methods which would return void to return a Response instead.