### PR TITLE
Make generic model compatible with PHP 8.1

### DIFF
--- a/src/main/resources/handlebars/php/model_generic.mustache
+++ b/src/main/resources/handlebars/php/model_generic.mustache
@@ -353,6 +353,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange] 
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange] 
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -378,6 +380,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange] 
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange] 
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);


### PR DESCRIPTION
Refs https://github.com/swagger-api/swagger-codegen/issues/11820, port of https://github.com/swagger-api/swagger-codegen/pull/11846 for 3.0 

Add #[\ReturnTypeWillChange] (https://php.watch/versions/8.1/ReturnTypeWillChange) to avoid deprecation notices.