### PR TITLE
Golang fix integer enum 

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
@@ -530,7 +530,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
         enumName = enumName.replaceFirst("^_", "");
         enumName = enumName.replaceFirst("_$", "");
 
-        return formatSpecialEnumName(name);
+        return formatSpecialEnumSymbol(name);
     }
 
     @Override
@@ -589,7 +589,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
         return name;
     }
 
-    protected String formatSpecialEnumName(String name) {
+    protected String formatSpecialEnumSymbol(String name) {
         // for reserved word or word starting with number, append _
         if (isReservedWord(name))
             name = escapeReservedWord(name);

--- a/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
@@ -148,7 +148,15 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
         // pet_id => PetId
         name = camelize(name);
 
-        return formatSpecialName(name);
+        // for reserved word or word starting with number, append _
+        if (isReservedWord(name))
+            name = escapeReservedWord(name);
+
+        // for reserved word or word starting with number, append _
+        if (name.matches("^\\d.*"))
+            name = VAR_PREFIX + name;
+
+        return name;
     }
 
     @Override
@@ -530,7 +538,14 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
         enumName = enumName.replaceFirst("^_", "");
         enumName = enumName.replaceFirst("_$", "");
 
-        return formatSpecialEnumSymbol(name);
+        // for reserved word, append _
+        if (isReservedWord(enumName))
+            enumName = escapeReservedWord(enumName);
+
+        if (enumName.matches("^\\d.*"))
+            enumName = ENUM_SYMBOL_PREFIX + enumName;
+
+        return enumName;
     }
 
     @Override
@@ -575,29 +590,5 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
     @Override
     public boolean checkAliasModel() {
         return true;
-    }
-
-    protected String formatSpecialName(String name) {
-        // for reserved word or word starting with number, append _
-        if (isReservedWord(name))
-            name = escapeReservedWord(name);
-
-        // for reserved word or word starting with number, append _
-        if (name.matches("^\\d.*"))
-            name = VAR_PREFIX + name;
-
-        return name;
-    }
-
-    protected String formatSpecialEnumSymbol(String name) {
-        // for reserved word or word starting with number, append _
-        if (isReservedWord(name))
-            name = escapeReservedWord(name);
-
-        // for reserved word or word starting with number, append _
-        if (name.matches("^\\d.*"))
-            name = ENUM_SYMBOL_PREFIX + name;
-
-        return name;
     }
 }

--- a/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
@@ -42,7 +42,8 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
 
     protected String packageName = "swagger";
 
-    protected static final String PREFIX_VAR = "Var";
+    protected static final String VAR_PREFIX = "Var";
+    protected static final String ENUM_SYMBOL_PREFIX = "Symbol_";
 
     public AbstractGoCodegen() {
         super();
@@ -529,7 +530,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
         enumName = enumName.replaceFirst("^_", "");
         enumName = enumName.replaceFirst("_$", "");
 
-        return formatSpecialName(name);
+        return formatSpecialEnumName(name);
     }
 
     @Override
@@ -583,7 +584,19 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
 
         // for reserved word or word starting with number, append _
         if (name.matches("^\\d.*"))
-            name = PREFIX_VAR + name;
+            name = VAR_PREFIX + name;
+
+        return name;
+    }
+
+    protected String formatSpecialEnumName(String name) {
+        // for reserved word or word starting with number, append _
+        if (isReservedWord(name))
+            name = escapeReservedWord(name);
+
+        // for reserved word or word starting with number, append _
+        if (name.matches("^\\d.*"))
+            name = ENUM_SYMBOL_PREFIX + name;
 
         return name;
     }

--- a/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
@@ -42,6 +42,8 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
 
     protected String packageName = "swagger";
 
+    protected static final String PREFIX_VAR = "Var";
+
     public AbstractGoCodegen() {
         super();
 
@@ -145,15 +147,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
         // pet_id => PetId
         name = camelize(name);
 
-        // for reserved word or word starting with number, append _
-        if (isReservedWord(name))
-            name = escapeReservedWord(name);
-
-        // for reserved word or word starting with number, append _
-        if (name.matches("^\\d.*"))
-            name = "Var" + name;
-
-        return name;
+        return formatSpecialName(name);
     }
 
     @Override
@@ -535,11 +529,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
         enumName = enumName.replaceFirst("^_", "");
         enumName = enumName.replaceFirst("_$", "");
 
-        if (isReservedWord(enumName) || enumName.matches("\\d.*")) { // reserved word or starts with number
-            return escapeReservedWord(enumName);
-        } else {
-            return enumName;
-        }
+        return formatSpecialName(name);
     }
 
     @Override
@@ -584,5 +574,17 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
     @Override
     public boolean checkAliasModel() {
         return true;
+    }
+
+    protected String formatSpecialName(String name) {
+        // for reserved word or word starting with number, append _
+        if (isReservedWord(name))
+            name = escapeReservedWord(name);
+
+        // for reserved word or word starting with number, append _
+        if (name.matches("^\\d.*"))
+            name = PREFIX_VAR + name;
+
+        return name;
     }
 }

--- a/src/test/java/io/swagger/codegen/v3/generators/go/GoEnumModelTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/go/GoEnumModelTest.java
@@ -9,7 +9,20 @@ public class GoEnumModelTest {
     DefaultCodegenConfig codegen = new GoClientCodegen();
 
     @Test
-    public void enumOfIntegerStartsWithUpperCaseLetterTest() {
+    public void enumVarNameStartsWithUpperCaseLetterTest() {
+        final String value = "1";
+        final String actual = codegen.toEnumVarName(value, "int32");
+
+        final char[] firstSymbolArray = new char[1];
+        actual.getChars(0, 1, firstSymbolArray, 0);
+
+        final char firstSymbol = firstSymbolArray[0];
+        Assert.assertTrue(Character.isLetter(firstSymbol), firstSymbol + " is not a letter");
+        Assert.assertTrue(Character.isUpperCase(firstSymbol), firstSymbol + " is not an uppercase letter");
+    }
+
+    @Test
+    public void enumVarNameStartsWithPrefixTest() {
         final String value = "1";
         Assert.assertEquals(
             codegen.toEnumVarName(value, "int32"),

--- a/src/test/java/io/swagger/codegen/v3/generators/go/GoEnumModelTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/go/GoEnumModelTest.java
@@ -1,0 +1,19 @@
+package io.swagger.codegen.v3.generators.go;
+
+import io.swagger.codegen.v3.generators.DefaultCodegenConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class GoEnumModelTest {
+
+    DefaultCodegenConfig codegen = new GoClientCodegen();
+
+    @Test
+    public void enumOfIntegerStartsWithUpperCaseLetterTest() {
+        final String value = "1";
+        Assert.assertEquals(
+            codegen.toEnumVarName(value, "int32"),
+            GoClientCodegen.ENUM_SYMBOL_PREFIX + value
+        );
+    }
+}


### PR DESCRIPTION
Golang requires enum symbols to start with a letter, so I did changes to add prefix to enum symbols when they begin with a number
[Here](https://pastebin.com/3gusNGMn) you can download an open API specification from my production as a showcase of incorrect code generation (file's name is _model_node_type.go_)
```
package swagger
// NodeType : Allowed node type
type NodeType int32

// List of NodeType
const (
	1__NodeType NodeType = "1"
	3__NodeType NodeType = "3"
	4__NodeType NodeType = "4"
	5__NodeType NodeType = "5"
)
```
And this PR turns code from abode to this
```
package swagger
// NodeType : Allowed node type
type NodeType int32

// List of NodeType
const (
	Symbol_1_NodeType NodeType = "1"
	Symbol_3_NodeType NodeType = "3"
	Symbol_4_NodeType NodeType = "4"
	Symbol_5_NodeType NodeType = "5"
)