### PR TITLE
PHP: beautify templates

### DIFF
--- a/src/main/resources/handlebars/php/model_enum.mustache
+++ b/src/main/resources/handlebars/php/model_enum.mustache
@@ -3,8 +3,11 @@ class {{classname}}
     /**
      * Possible values of this enum
      */
-    {{#allowableValues}}{{#enumVars}}const {{{name}}} = {{{value}}};
-    {{/enumVars}}{{/allowableValues}}
+    {{#allowableValues}}
+    {{#enumVars}}
+    const {{{name}}} = {{{value}}};
+    {{/enumVars}}
+    {{/allowableValues}}
     /**
      * Gets allowable values of the enum
      * @return string[]
@@ -12,8 +15,11 @@ class {{classname}}
     public static function getAllowableEnumValues()
     {
         return [
-            {{#allowableValues}}{{#enumVars}}self::{{{name}}},{{^@last}}
-            {{/@last}}{{/enumVars}}{{/allowableValues}}
+            {{#allowableValues}}
+            {{#enumVars}}
+            self::{{{name}}}{{#hasMore}},{{/hasMore}}
+            {{/enumVars}}
+            {{/allowableValues}}
         ];
     }
 }

--- a/src/main/resources/handlebars/php/model_generic.mustache
+++ b/src/main/resources/handlebars/php/model_generic.mustache
@@ -16,9 +16,6 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
       */
     protected static $swaggerTypes = [
         {{#vars}}
-        {{#description}}
-        // {{{description}}}
-        {{/description}}
         '{{name}}' => '{{{datatype}}}'{{#hasMore}},{{/hasMore}}
         {{/vars}}
     ];

--- a/src/main/resources/handlebars/php/model_generic.mustache
+++ b/src/main/resources/handlebars/php/model_generic.mustache
@@ -15,8 +15,12 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
       * @var string[]
       */
     protected static $swaggerTypes = [
-        {{#vars}}'{{name}}' => '{{{datatype}}}'{{#hasMore}},
-        {{/hasMore}}{{/vars}}
+        {{#vars}}
+        {{#description}}
+        // {{{description}}}
+        {{/description}}
+        '{{name}}' => '{{{datatype}}}'{{#hasMore}},{{/hasMore}}
+        {{/vars}}
     ];
 
     /**
@@ -25,8 +29,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
       * @var string[]
       */
     protected static $swaggerFormats = [
-        {{#vars}}'{{name}}' => {{#dataFormat}}'{{{dataFormat}}}'{{/dataFormat}}{{^dataFormat}}null{{/dataFormat}}{{#hasMore}},
-        {{/hasMore}}{{/vars}}
+        {{#vars}}
+        '{{name}}' => {{#dataFormat}}'{{{dataFormat}}}'{{/dataFormat}}{{^dataFormat}}null{{/dataFormat}}{{#hasMore}},{{/hasMore}}
+        {{/vars}}
     ];
 
     /**
@@ -56,8 +61,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
      * @var string[]
      */
     protected static $attributeMap = [
-        {{#vars}}'{{name}}' => '{{baseName}}'{{#hasMore}},
-        {{/hasMore}}{{/vars}}
+        {{#vars}}
+        '{{name}}' => '{{baseName}}'{{#hasMore}},{{/hasMore}}
+        {{/vars}}
     ];
 
     /**
@@ -66,8 +72,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
      * @var string[]
      */
     protected static $setters = [
-        {{#vars}}'{{name}}' => '{{setter}}'{{#hasMore}},
-        {{/hasMore}}{{/vars}}
+        {{#vars}}
+        '{{name}}' => '{{setter}}'{{#hasMore}},{{/hasMore}}
+        {{/vars}}
     ];
 
     /**
@@ -76,8 +83,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
      * @var string[]
      */
     protected static $getters = [
-        {{#vars}}'{{name}}' => '{{getter}}'{{#hasMore}},
-        {{/hasMore}}{{/vars}}
+        {{#vars}}
+        '{{name}}' => '{{getter}}'{{#hasMore}},{{/hasMore}}
+        {{/vars}}
     ];
 
     /**
@@ -121,10 +129,18 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         return self::$swaggerModelName;
     }
 
-    {{#vars}}{{#isEnum}}{{#allowableValues}}{{#enumVars}}const {{enumName}}_{{{name}}} = {{{value}}};
-    {{/enumVars}}{{/allowableValues}}{{/isEnum}}{{/vars}}
+    {{#vars}}
+    {{#isEnum}}
+    {{#allowableValues}}
+    {{#enumVars}}
+    const {{enumName}}_{{{name}}} = {{{value}}};
+    {{/enumVars}}
+    {{/allowableValues}}
+    {{/isEnum}}
+    {{/vars}}
 
-    {{#vars}}{{#isEnum}}
+    {{#vars}}
+    {{#isEnum}}
     /**
      * Gets allowable values of the enum
      *
@@ -133,11 +149,15 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
     public function {{getter}}AllowableValues()
     {
         return [
-            {{#allowableValues}}{{#enumVars}}self::{{enumName}}_{{{name}}},{{^@last}}
-            {{/@last}}{{/enumVars}}{{/allowableValues}}
+            {{#allowableValues}}
+            {{#enumVars}}
+            self::{{enumName}}_{{{name}}}{{#hasMore}},{{/hasMore}}
+            {{/enumVars}}
+            {{/allowableValues}}
         ];
     }
-    {{/isEnum}}{{/vars}}
+    {{/isEnum}}
+    {{/vars}}
 
     {{^parentSchema}}
     /**


### PR DESCRIPTION
Fix variable formatting from this
```
[
        'a' => 'string',
'b' => 'string',
'c' => 'string',
'd' => 'string' ];
```
to this
```

[
        'a' => 'string',
        'b' => 'string',
        'c' => 'string',
        'd' => 'string'
];
```