### PR TITLE
replace deprecated org.springframework.util.Base64Utils with Base64

### DIFF
--- a/src/main/resources/handlebars/Java/libraries/resttemplate/auth/HttpBasicAuth.mustache
+++ b/src/main/resources/handlebars/Java/libraries/resttemplate/auth/HttpBasicAuth.mustache
@@ -2,9 +2,9 @@ package {{invokerPackage}}.auth;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.MultiValueMap;
 
 {{>generatedAnnotation}}
@@ -34,6 +34,6 @@ public class HttpBasicAuth implements Authentication {
             return;
         }
         String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
-        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString(str.getBytes(StandardCharsets.UTF_8)));
+        headerParams.add(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(str.getBytes(StandardCharsets.UTF_8)));
     }
 }


### PR DESCRIPTION
I may be wrong (the 3.0.0 branch and splitted codebase is not easy to grok) but I think that this is the right place to fix https://github.com/swagger-api/swagger-codegen/issues/12080