### PR TITLE
Fix file and binary response handling.

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -2353,7 +2353,11 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
             }
             codegenResponse.dataType = codegenProperty.datatype;
 
-            if (getBooleanValue(codegenProperty, CodegenConstants.IS_STRING_EXT_NAME)) {
+            if (getBooleanValue(codegenProperty, CodegenConstants.IS_FILE_EXT_NAME)) {
+                codegenResponse.getVendorExtensions().put(CodegenConstants.IS_FILE_EXT_NAME, Boolean.TRUE);
+            } if (getBooleanValue(codegenProperty, CodegenConstants.IS_BINARY_EXT_NAME)) {
+                codegenResponse.getVendorExtensions().put(CodegenConstants.IS_BINARY_EXT_NAME, Boolean.TRUE);
+            } else if (getBooleanValue(codegenProperty, CodegenConstants.IS_STRING_EXT_NAME)) {
                 codegenResponse.getVendorExtensions().put(CodegenConstants.IS_STRING_EXT_NAME, Boolean.TRUE);
             } else if (getBooleanValue(codegenProperty, CodegenConstants.IS_BOOLEAN_EXT_NAME)) {
                 codegenResponse.getVendorExtensions().put(CodegenConstants.IS_BOOLEAN_EXT_NAME, Boolean.TRUE);
@@ -2371,10 +2375,6 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
                 codegenResponse.getVendorExtensions().put(CodegenConstants.IS_NUMERIC_EXT_NAME, Boolean.TRUE);
             } else if (getBooleanValue(codegenProperty, CodegenConstants.IS_BYTE_ARRAY_EXT_NAME)) {
                 codegenResponse.getVendorExtensions().put(CodegenConstants.IS_BYTE_ARRAY_EXT_NAME, Boolean.TRUE);
-            } else if (getBooleanValue(codegenProperty, CodegenConstants.IS_BINARY_EXT_NAME)) {
-                codegenResponse.getVendorExtensions().put(CodegenConstants.IS_BINARY_EXT_NAME, Boolean.TRUE);
-            } else if (getBooleanValue(codegenProperty, CodegenConstants.IS_FILE_EXT_NAME)) {
-                codegenResponse.getVendorExtensions().put(CodegenConstants.IS_FILE_EXT_NAME, Boolean.TRUE);
             } else if (getBooleanValue(codegenProperty, CodegenConstants.IS_DATE_EXT_NAME)) {
                 codegenResponse.getVendorExtensions().put(CodegenConstants.IS_DATE_EXT_NAME, Boolean.TRUE);
             } else if (getBooleanValue(codegenProperty, CodegenConstants.IS_DATE_TIME_EXT_NAME)) {


### PR DESCRIPTION
According to OpenApi v3 documentation binary file uploads have response type string.
https://swagger.io/docs/specification/describing-responses/

This is why we need to check for file and binary types before checking for string type.