### PR TITLE
fixed model name prefix/suffix issues

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/go/AbstractGoCodegen.java
@@ -180,11 +180,13 @@ public abstract class AbstractGoCodegen extends DefaultCodegenConfig {
     }
 
     public String toModel(String name) {
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
+        if (!StringUtils.isEmpty(modelNamePrefix) &&
+            !name.toLowerCase().startsWith(modelNamePrefix.toLowerCase())) {
             name = modelNamePrefix + "_" + name;
         }
 
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
+        if (!StringUtils.isEmpty(modelNameSuffix) &&
+            !name.toLowerCase().endsWith(modelNameSuffix.toLowerCase())) {
             name = name + "_" + modelNameSuffix;
         }
 

--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -678,12 +678,15 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         final String sanitizedName = sanitizeName(name);
 
         String nameWithPrefixSuffix = sanitizedName;
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
+        if (!StringUtils.isEmpty(modelNamePrefix) &&
+            !nameWithPrefixSuffix.toLowerCase().startsWith(modelNamePrefix.toLowerCase())) {
             // add '_' so that model name can be camelized correctly
             nameWithPrefixSuffix = modelNamePrefix + "_" + nameWithPrefixSuffix;
         }
 
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
+
+        if (!StringUtils.isEmpty(modelNameSuffix) &&
+            !nameWithPrefixSuffix.toLowerCase().endsWith(modelNameSuffix.toLowerCase())) {
             // add '_' so that model name can be camelized correctly
             nameWithPrefixSuffix = nameWithPrefixSuffix + "_" + modelNameSuffix;
         }

--- a/src/main/java/io/swagger/codegen/v3/generators/javascript/JavaScriptClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/javascript/JavaScriptClientCodegen.java
@@ -596,11 +596,13 @@ public class JavaScriptClientCodegen extends DefaultCodegenConfig {
         }
         name = sanitizeName(name);  // FIXME parameter should not be assigned. Also declare it as "final"
 
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
+        if (!StringUtils.isEmpty(modelNamePrefix) &&
+	    !name.toLowerCase().startsWith(modelNamePrefix.toLowerCase())) {
             name = modelNamePrefix + "_" + name;
         }
 
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
+        if (!StringUtils.isEmpty(modelNameSuffix) &&
+            !name.toLowerCase().endsWith(modelNameSuffix.toLowerCase())) {
             name = name + "_" + modelNameSuffix;
         }
 

--- a/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/python/PythonClientCodegen.java
@@ -491,11 +491,13 @@ public class PythonClientCodegen extends DefaultCodegenConfig {
             name = "model_" + name; // e.g. 200Response => Model200Response (after camelize)
         }
 
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
+        if (!StringUtils.isEmpty(modelNamePrefix) &&
+            !name.toLowerCase().startsWith(modelNamePrefix.toLowerCase())) {
             name = modelNamePrefix + "_" + name;
         }
 
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
+        if (!StringUtils.isEmpty(modelNameSuffix) &&
+            !name.toLowerCase().endsWith(modelNameSuffix.toLowerCase())) {
             name = name + "_" + modelNameSuffix;
         }
 

--- a/src/main/java/io/swagger/codegen/v3/generators/python/PythonFlaskConnexionCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/python/PythonFlaskConnexionCodegen.java
@@ -461,11 +461,13 @@ public class PythonFlaskConnexionCodegen extends DefaultCodegenConfig {
             name = "model_" + name; // e.g. 200Response => Model200Response (after camelize)
         }
 
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
+        if (!StringUtils.isEmpty(modelNamePrefix) &&
+            !name.toLowerCase().startsWith(modelNamePrefix.toLowerCase())) {
             name = modelNamePrefix + "_" + name;
         }
 
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
+        if (!StringUtils.isEmpty(modelNameSuffix) &&
+            !name.toLowerCase().endsWith(modelNameSuffix.toLowerCase())) {
             name = name + "_" + modelNameSuffix;
         }
 

--- a/src/main/java/io/swagger/codegen/v3/generators/r/RClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/r/RClientCodegen.java
@@ -217,11 +217,13 @@ public class RClientCodegen extends DefaultCodegenConfig {
 
     @Override
     public String toModelFilename(String name) {
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
+        if (!StringUtils.isEmpty(modelNamePrefix) &&
+            !name.toLowerCase().startsWith(modelNamePrefix.toLowerCase())) {
             name = modelNamePrefix + "_" + name;
         }
 
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
+        if (!StringUtils.isEmpty(modelNameSuffix) &&
+            !name.toLowerCase().endsWith(modelNameSuffix.toLowerCase())) {
             name = name + "_" + modelNameSuffix;
         }
 

--- a/src/main/java/io/swagger/codegen/v3/generators/ruby/RubyClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/ruby/RubyClientCodegen.java
@@ -445,11 +445,13 @@ public class RubyClientCodegen extends DefaultCodegenConfig {
     public String toModelName(String name) {
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
+        if (!StringUtils.isEmpty(modelNamePrefix) &&
+            !name.toLowerCase().startsWith(modelNamePrefix.toLowerCase())) {
             name = modelNamePrefix + "_" + name;
         }
 
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
+        if (!StringUtils.isEmpty(modelNameSuffix) &&
+            !name.toLowerCase().endsWith(modelNameSuffix.toLowerCase())) {
             name = name + "_" + modelNameSuffix;
         }
 

--- a/src/main/java/io/swagger/codegen/v3/generators/swift/AbstractSwiftCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/swift/AbstractSwiftCodegen.java
@@ -311,11 +311,13 @@ public abstract class AbstractSwiftCodegen extends DefaultCodegenConfig {
         // FIXME parameter should not be assigned. Also declare it as "final"
         name = sanitizeName(name);
 
-        if (!StringUtils.isEmpty(modelNameSuffix)) { // set model suffix
+        if (!StringUtils.isEmpty(modelNameSuffix) &&
+            !name.toLowerCase().endsWith(modelNameSuffix.toLowerCase())) { // set model suffix
             name = name + "_" + modelNameSuffix;
         }
 
-        if (!StringUtils.isEmpty(modelNamePrefix)) { // set model prefix
+        if (!StringUtils.isEmpty(modelNamePrefix) &&
+            !name.toLowerCase().startsWith(modelNamePrefix.toLowerCase())) { // set model prefix
             name = modelNamePrefix + "_" + name;
         }
 

--- a/src/main/java/io/swagger/codegen/v3/generators/swift/Swift5Codegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/swift/Swift5Codegen.java
@@ -435,11 +435,13 @@ public class Swift5Codegen extends DefaultCodegenConfig {
         // FIXME parameter should not be assigned. Also declare it as "final"
         name = sanitizeName(name);
 
-        if (!StringUtils.isEmpty(modelNameSuffix)) { // set model suffix
+        if (!StringUtils.isEmpty(modelNameSuffix) &&
+            !name.toLowerCase().endsWith(modelNameSuffix.toLowerCase())) { // set model suffix
             name = name + "_" + modelNameSuffix;
         }
 
-        if (!StringUtils.isEmpty(modelNamePrefix)) { // set model prefix
+        if (!StringUtils.isEmpty(modelNamePrefix) &&
+            !name.toLowerCase().startsWith(modelNamePrefix.toLowerCase())) { // set model prefix
             name = modelNamePrefix + "_" + name;
         }
 

--- a/src/main/java/io/swagger/codegen/v3/generators/typescript/AbstractTypeScriptClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/typescript/AbstractTypeScriptClientCodegen.java
@@ -190,11 +190,13 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegenConf
     public String toModelName(String name) {
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
+        if (!StringUtils.isEmpty(modelNamePrefix) &&
+            !name.toLowerCase().startsWith(modelNamePrefix.toLowerCase())) {
             name = modelNamePrefix + "_" + name;
         }
 
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
+        if (!StringUtils.isEmpty(modelNameSuffix) &&
+            !name.toLowerCase().endsWith(modelNameSuffix.toLowerCase())) {
             name = name + "_" + modelNameSuffix;
         }
 


### PR DESCRIPTION
Fixed model name prefix/suffix generator issues where the prefix/suffix can be duplicated in the api/controller client codes.
- fixes swagger-api/swagger-codegen#7865
- fixes swagger-api/swagger-codegen#7866