### PR TITLE
set default 'ignore mapping' option for java generators with 'false'

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -1052,7 +1052,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
 
         for (CodegenProperty codegenProperty : codegenModel.vars) {
             CodegenModel parentModel = codegenModel.parentModel;
-            
+
             while (parentModel != null) {
                 if (parentModel.vars == null || parentModel.vars.isEmpty()) {
                     parentModel = parentModel.parentModel;
@@ -1675,11 +1675,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         }
 
         super.setLanguageArguments(languageArguments);
-    }
-
-    @Override
-    public boolean defaultIgnoreImportMappingOption() {
-        return true;
     }
 
     @Override


### PR DESCRIPTION
fixes https://github.com/swagger-api/swagger-codegen/issues/10419 for codegen v3