### PR TITLE
JSON stringify for query parameters

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -2513,6 +2513,8 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
             codegenParameter.dataType = codegenProperty.datatype;
             codegenParameter.dataFormat = codegenProperty.dataFormat;
 
+            setParameterJson(codegenParameter, parameterSchema);
+
             if (getBooleanValue(codegenProperty, IS_ENUM_EXT_NAME)) {
                 codegenParameter.datatypeWithEnum = codegenProperty.datatypeWithEnum;
                 codegenParameter.enumName = codegenProperty.enumName;
@@ -4401,6 +4403,14 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
 
     protected void setParameterNullable(CodegenParameter parameter, CodegenProperty property) {
         parameter.nullable = property.nullable;
+    }
+
+    protected void setParameterJson(CodegenParameter codegenParameter, Schema parameterSchema) {
+        String contentType = parameterSchema.getExtensions() == null ? null : (String) parameterSchema.getExtensions().get("x-content-type");
+        if (contentType != null && contentType.startsWith("application/") && contentType.endsWith("json")) {
+            // application/json, application/problem+json, application/ld+json, some more?
+            codegenParameter.isJson = true;
+        }
     }
 
     @Override

--- a/src/main/resources/handlebars/typescript-angular/api.service.mustache
+++ b/src/main/resources/handlebars/typescript-angular/api.service.mustache
@@ -175,7 +175,12 @@ export class {{classname}} {
             {{#useHttpClient}}queryParameters = {{/useHttpClient}}queryParameters.set('{{baseName}}', <any>{{paramName}}.toISOString());
         {{/isDateTime}}
         {{^isDateTime}}
+            {{#isJson}}
+            {{#useHttpClient}}queryParameters = {{/useHttpClient}}queryParameters.set('{{baseName}}', JSON.stringify({{paramName}}));
+            {{/isJson}}
+            {{^isJson}}
             {{#useHttpClient}}queryParameters = {{/useHttpClient}}queryParameters.set('{{baseName}}', <any>{{paramName}});
+            {{/isJson}}
         {{/isDateTime}}
         }
         {{/isListContainer}}


### PR DESCRIPTION
As described in issue #1173, OpenAPI allows query parameters to be JSON objects. However these are not handled correctly in typescript generated code.

With this PR, if we recognize that a query parameter has JSON as content-type, we force a `JSON.stringify` in generated typescript code, before http call.

This PR requires that a new parameter `isJson` is created on class `CodegenParameter`. See https://github.com/swagger-api/swagger-codegen/pull/12289.