### PR TITLE
fix for #804 + java interface discriminator mapping fix

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -3,30 +3,9 @@ package io.swagger.codegen.v3.generators;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.jknack.handlebars.Handlebars;
 import com.samskivert.mustache.Mustache;
-import io.swagger.codegen.v3.CliOption;
-import io.swagger.codegen.v3.CodegenArgument;
-import io.swagger.codegen.v3.CodegenConfig;
-import io.swagger.codegen.v3.CodegenConstants;
-import io.swagger.codegen.v3.CodegenContent;
-import io.swagger.codegen.v3.CodegenModel;
-import io.swagger.codegen.v3.CodegenModelFactory;
-import io.swagger.codegen.v3.CodegenModelType;
-import io.swagger.codegen.v3.CodegenOperation;
-import io.swagger.codegen.v3.CodegenParameter;
-import io.swagger.codegen.v3.CodegenProperty;
-import io.swagger.codegen.v3.CodegenResponse;
-import io.swagger.codegen.v3.CodegenSecurity;
-import io.swagger.codegen.v3.ISchemaHandler;
-import io.swagger.codegen.v3.SupportingFile;
+import io.swagger.codegen.v3.*;
 import io.swagger.codegen.v3.generators.examples.ExampleGenerator;
-import io.swagger.codegen.v3.generators.handlebars.BaseItemsHelper;
-import io.swagger.codegen.v3.generators.handlebars.BracesHelper;
-import io.swagger.codegen.v3.generators.handlebars.HasHelper;
-import io.swagger.codegen.v3.generators.handlebars.HasNotHelper;
-import io.swagger.codegen.v3.generators.handlebars.IsHelper;
-import io.swagger.codegen.v3.generators.handlebars.IsNotHelper;
-import io.swagger.codegen.v3.generators.handlebars.NotEmptyHelper;
-import io.swagger.codegen.v3.generators.handlebars.StringUtilHelper;
+import io.swagger.codegen.v3.generators.handlebars.*;
 import io.swagger.codegen.v3.generators.util.OpenAPIUtil;
 import io.swagger.codegen.v3.templates.HandlebarTemplateEngine;
 import io.swagger.codegen.v3.templates.MustacheTemplateEngine;
@@ -38,30 +17,8 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.headers.Header;
-import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.BinarySchema;
-import io.swagger.v3.oas.models.media.BooleanSchema;
-import io.swagger.v3.oas.models.media.ByteArraySchema;
-import io.swagger.v3.oas.models.media.ComposedSchema;
-import io.swagger.v3.oas.models.media.Content;
-import io.swagger.v3.oas.models.media.DateSchema;
-import io.swagger.v3.oas.models.media.DateTimeSchema;
-import io.swagger.v3.oas.models.media.EmailSchema;
-import io.swagger.v3.oas.models.media.FileSchema;
-import io.swagger.v3.oas.models.media.IntegerSchema;
-import io.swagger.v3.oas.models.media.MapSchema;
-import io.swagger.v3.oas.models.media.MediaType;
-import io.swagger.v3.oas.models.media.NumberSchema;
-import io.swagger.v3.oas.models.media.ObjectSchema;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.media.StringSchema;
-import io.swagger.v3.oas.models.media.UUIDSchema;
-import io.swagger.v3.oas.models.parameters.CookieParameter;
-import io.swagger.v3.oas.models.parameters.HeaderParameter;
-import io.swagger.v3.oas.models.parameters.Parameter;
-import io.swagger.v3.oas.models.parameters.PathParameter;
-import io.swagger.v3.oas.models.parameters.QueryParameter;
-import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.parameters.*;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.OAuthFlow;
@@ -99,16 +56,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static io.swagger.codegen.v3.CodegenConstants.HAS_ONLY_READ_ONLY_EXT_NAME;
-import static io.swagger.codegen.v3.CodegenConstants.HAS_OPTIONAL_EXT_NAME;
-import static io.swagger.codegen.v3.CodegenConstants.HAS_REQUIRED_EXT_NAME;
-import static io.swagger.codegen.v3.CodegenConstants.IS_ARRAY_MODEL_EXT_NAME;
-import static io.swagger.codegen.v3.CodegenConstants.IS_CONTAINER_EXT_NAME;
-import static io.swagger.codegen.v3.CodegenConstants.IS_ENUM_EXT_NAME;
-import static io.swagger.codegen.v3.generators.CodegenHelper.getDefaultIncludes;
-import static io.swagger.codegen.v3.generators.CodegenHelper.getImportMappings;
-import static io.swagger.codegen.v3.generators.CodegenHelper.getTypeMappings;
-import static io.swagger.codegen.v3.generators.CodegenHelper.initalizeSpecialCharacterMapping;
+import static io.swagger.codegen.v3.CodegenConstants.*;
+import static io.swagger.codegen.v3.generators.CodegenHelper.*;
 import static io.swagger.codegen.v3.generators.handlebars.ExtensionHelper.getBooleanValue;
 
 public abstract class DefaultCodegenConfig implements CodegenConfig {
@@ -1345,9 +1294,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
         codegenModel.getVendorExtensions().put(CodegenConstants.IS_ALIAS_EXT_NAME, typeAliases.containsKey(name));
 
         codegenModel.discriminator = schema.getDiscriminator();
-        if (codegenModel.discriminator != null && codegenModel.discriminator.getPropertyName() != null) {
-            codegenModel.discriminator.setPropertyName(toVarName(codegenModel.discriminator.getPropertyName()));
-        }
+
 
         if (schema.getXml() != null) {
             codegenModel.xmlPrefix = schema.getXml().getPrefix();
@@ -1398,6 +1345,33 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
                         }
                     }
                 }
+
+                if (codegenModel.discriminator != null && codegenModel.discriminator.getPropertyName() != null) {
+                    codegenModel.discriminator.setPropertyName(toVarName(codegenModel.discriminator.getPropertyName()));
+                    Map<String, String> classnameKeys = new HashMap<>();
+
+                    if (composed.getOneOf()!=null) {
+                        composed.getOneOf().forEach( s -> {
+
+                            codegenModel.discriminator.getMapping().keySet().stream().filter( key -> codegenModel.discriminator.getMapping().get(key).equals(s.get$ref()))
+                                .forEach(key -> {
+                                    String mappingValue = codegenModel.discriminator.getMapping().get(key);
+                                    if (classnameKeys.containsKey(codegenModel.classname)) {
+                                        throw new IllegalArgumentException("Duplicate shema name in discriminator mapping");
+                                    }
+                                    classnameKeys.put(toModelName(mappingValue.replace("#/components/schemas/", "")),key);
+                                });
+
+                        });
+
+                        codegenModel.discriminator.getMapping().putAll(classnameKeys);
+
+                    }
+
+
+                }
+
+
             } else {
                 allProperties = null;
                 allRequired = null;

--- a/src/main/java/io/swagger/codegen/v3/generators/SchemaHandler.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/SchemaHandler.java
@@ -199,9 +199,7 @@ public class SchemaHandler implements ISchemaHandler {
                 codegenModel.addSubType(model);
             }
 
-            if (codegenModel.getVendorExtensions() == null || codegenModel.getVendorExtensions().containsKey("x-discriminator-type")) {
-                continue;
-            }
+
             if (codegenModel.getDiscriminator() != null && StringUtils.isNotBlank(codegenModel.getDiscriminator().getPropertyName())) {
                 Optional<CodegenProperty> optionalProperty = model.vars.stream()
                     .filter(codegenProperty -> codegenProperty.baseName.equals(codegenModel.getDiscriminator().getPropertyName())).findFirst();

--- a/src/main/resources/handlebars/Java/interface.mustache
+++ b/src/main/resources/handlebars/Java/interface.mustache
@@ -9,10 +9,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
-  property = "type")
+  property = "{{discriminator.propertyName}}")
 @JsonSubTypes({
   {{#subTypes}}
-  @JsonSubTypes.Type(value = {{classname}}.class, name = "{{classname}}"){{^@last}},{{/@last}}
+  @JsonSubTypes.Type(value = {{classname}}.class, name = "{{subtypeName}}"){{^@last}},{{/@last}}
   {{/subTypes}}
 })
 {{/jackson}}

--- a/src/main/resources/handlebars/Java/typeInfoAnnotation.mustache
+++ b/src/main/resources/handlebars/Java/typeInfoAnnotation.mustache
@@ -2,6 +2,6 @@
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{discriminator.propertyName}}", visible = true )
 @JsonSubTypes({
   {{#children}}
-  @JsonSubTypes.Type(value = {{classname}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),
+  @JsonSubTypes.Type(value = {{classname}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{subtypeName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),
   {{/children}}
 }){{/jackson}}

--- a/src/test/java/io/swagger/codegen/v3/generators/GeneratorRunner.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/GeneratorRunner.java
@@ -13,6 +13,8 @@ import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  *
@@ -28,7 +30,8 @@ public abstract class GeneratorRunner {
         boolean v2Spec,
         boolean yaml,
         boolean flattenInlineComposedSchema,
-        String outFolder
+        String outFolder,
+        Consumer<Options> optionsCustomizer
     ) throws Exception {
 
         String path = outFolder;
@@ -36,6 +39,13 @@ public abstract class GeneratorRunner {
             path = getTmpFolder().getAbsolutePath();
         }
         GenerationRequest request = new GenerationRequest();
+
+        Options option = new Options()
+            .flattenInlineComposedSchema(flattenInlineComposedSchema)
+            .outputDir(path);
+
+        optionsCustomizer.accept(option);
+
         request
             .codegenVersion(codegenVersion) // use V2 to target Swagger/OpenAPI 2.x Codegen version
             .type(GenerationRequest.Type.CLIENT)
@@ -44,9 +54,7 @@ public abstract class GeneratorRunner {
                 yaml, // YAML file, use false for JSON
                 v2Spec)) // OpenAPI 3.x - use true for Swagger/OpenAPI 2.x definitions
             .options(
-                new Options()
-                    .flattenInlineComposedSchema(flattenInlineComposedSchema)
-                    .outputDir(path)
+                option
             );
 
         List<File> files = new GeneratorService().generationRequest(request).generate();

--- a/src/test/java/io/swagger/codegen/v3/generators/java/GeneratorResultTestJava.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/GeneratorResultTestJava.java
@@ -6,7 +6,11 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class GeneratorResultTestJava {
 
@@ -29,11 +33,59 @@ public class GeneratorResultTestJava {
             v2Spec,
             yaml,
             flattenInlineComposedSchema,
-            outFolder);
+            outFolder, options -> {});
 
         Assert.assertFalse(files.isEmpty());
         for (File f: files) {
             // TODO test stuff
         }
+    }
+
+    @Test
+    public void interfaceWithCustomDiscriminator() throws Exception {
+
+        String name = "java";
+        String specPath = "3_0_0/sample_interface_with_discriminator.json";
+        GenerationRequest.CodegenVersion codegenVersion = GenerationRequest.CodegenVersion.V3;
+        boolean v2Spec = false; // 3.0 spec
+        boolean yaml = false;
+        boolean flattenInlineComposedSchema = true;
+        String outFolder = null; // temporary folder
+
+
+        List<File> files = GeneratorRunner.runGenerator(
+            name,
+            specPath,
+            codegenVersion,
+            v2Spec,
+            yaml,
+            flattenInlineComposedSchema,
+            outFolder,
+            options -> options.setLibrary("resttemplate"));
+
+
+
+        File interfaceFile = files.stream().filter(f -> f.getName().equals("Item.java")).findAny().orElseThrow(() -> new RuntimeException("No interface generated"));
+
+        String interfaceContent = new String(Files.readAllBytes(Paths.get(interfaceFile.toURI())));
+
+        Pattern typeInfoPattern = Pattern.compile( 	"(.*)(@JsonTypeInfo\\()(.*)(}\\))(.*)", Pattern.DOTALL);
+
+        Matcher matcher = typeInfoPattern.matcher(interfaceContent);
+
+        Assert.assertTrue(matcher.matches(), "No JsonTypeInfo generated into the interface file");
+
+        String generatedTypeinfoLines = matcher.group(2)+matcher.group(3)+matcher.group(4);
+
+        Assert.assertEquals( generatedTypeinfoLines,"@JsonTypeInfo(\n" +
+            "  use = JsonTypeInfo.Id.NAME,\n" +
+            "  include = JsonTypeInfo.As.PROPERTY,\n" +
+            "  property = \"aCustomProperty\")\n" +
+            "@JsonSubTypes({\n" +
+            "  @JsonSubTypes.Type(value = ClassA.class, name = \"typeA\"),\n" +
+            "  @JsonSubTypes.Type(value = ClassB.class, name = \"typeB\"),\n" +
+            "  @JsonSubTypes.Type(value = ClassC.class, name = \"typeC\")\n" +
+            "})", "Wrong json subtypes generated");
+
     }
 }

--- a/src/test/java/io/swagger/codegen/v3/generators/java/JavaPolymorphicAnnotationCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/JavaPolymorphicAnnotationCodegenTest.java
@@ -31,10 +31,10 @@ public class JavaPolymorphicAnnotationCodegenTest {
         final String content = FileUtils.readFileToString(petControllerFile);
 
         Assert.assertTrue(content.contains(
-            "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = \"type\", visible = true )\n" +
-                "@JsonSubTypes({\n" +
-                "        @JsonSubTypes.Type(value = Error.class, name = \"Error\"),\n" +
-                "        @JsonSubTypes.Type(value = Success.class, name = \"Success\"),\n" +
+            "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = \"type\", visible = true )" + System.lineSeparator() +
+                "@JsonSubTypes({" + System.lineSeparator() +
+                "        @JsonSubTypes.Type(value = Error.class, name = \"Error\")," + System.lineSeparator() +
+                "        @JsonSubTypes.Type(value = Success.class, name = \"Success\")," + System.lineSeparator() +
                 "})"));
 
         this.folder.delete();

--- a/src/test/resources/3_0_0/javaDiscriminatorExample.yaml
+++ b/src/test/resources/3_0_0/javaDiscriminatorExample.yaml
@@ -1,0 +1,52 @@
+openapi: '3.0.3'
+info:
+  title: 'Discriminator Problem API'
+  version: '1.0.0'
+
+components:
+  schemas:
+    SomeTypeDTO:
+      type: string
+      enum:
+        - SubTypeA
+        - WeirdlyNamedSubTypeB
+
+    ResultForSubTypeDTO:
+      type: object
+      properties:
+        type:
+          type: string
+      oneOf:
+        - $ref: '#/components/schemas/SubTypeAResultDTO'
+        - $ref: '#/components/schemas/SubTypeBResultDTO'
+      required:
+        - type
+      discriminator:
+        propertyName: type
+        mapping:
+          SubTypeA: '#/components/schemas/SubTypeAResultDTO'
+          WeirdlyNamedSubTypeB: '#/components/schemas/SubTypeBResultDTO'
+
+    SubTypeAResultDTO:
+      allOf:
+        - $ref: '#/components/schemas/ResultForSubTypeDTO'
+      type: object
+      properties:
+        some_attribute:
+          type: string
+
+    SubTypeBResultDTO:
+      allOf:
+        - $ref: '#/components/schemas/ResultForSubTypeDTO'
+      type: object
+      properties:
+        another_attribute:
+          type: string
+
+paths:
+  /repro:
+    get:
+      operationId: 'getRepo'
+      responses:
+        204:
+          description: OK

--- a/src/test/resources/3_0_0/sample_interface_with_discriminator.json
+++ b/src/test/resources/3_0_0/sample_interface_with_discriminator.json
@@ -1,0 +1,118 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Title",
+    "description": "Title",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/sampleObjectResponse": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns requested data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sampleResponse"
+                }
+              }
+            }
+          }
+
+        }
+      }
+
+    }
+  },
+  "components": {
+    "schemas": {
+      "sampleResponse": {
+        "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/item"
+            }
+      },
+      "item": {
+        "discriminator": {
+          "propertyName": "aCustomProperty",
+          "mapping": {
+            "typeA": "#/components/schemas/classA",
+            "typeB": "#/components/schemas/classB",
+            "typeC": "#/components/schemas/classC"
+          }
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/classA"
+          },
+          {
+            "$ref": "#/components/schemas/classB"
+          },
+          {
+            "$ref": "#/components/schemas/classC"
+          }
+        ]
+      },
+      "classA": {
+        "type": "object",
+        "properties": {
+          "aaa": {
+            "type": "string"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/baseClass"
+          }
+        ]
+      },
+      "classB": {
+        "type": "object",
+        "properties": {
+          "bbb": {
+            "type": "string"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/baseClass"
+          }
+        ]
+      },
+      "classC": {
+        "type": "object",
+        "properties": {
+          "ccc": {
+            "type": "string"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/baseClass"
+          }
+        ]
+      },
+      "baseClass": {
+
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample",
+      "description": "Sample"
+    }
+  ]
+}


### PR DESCRIPTION
FIX for #804 
Added support of discriminator mapping for Java interfaces too.
The current template does not use the discriminator defined in the Openapi definition file.

The implemented solution generate from this definition:

>         "discriminator": {
>           "propertyName": "aCustomProperty",
>           "mapping": {
>             "typeA": "#/components/schemas/classA",
>             "typeB": "#/components/schemas/classB",
>             "typeC": "#/components/schemas/classC"
>           }
>         },

this interface

>   @JsonTypeInfo(
>     use = JsonTypeInfo.Id.NAME,
>     include = JsonTypeInfo.As.PROPERTY,
>     property = "**aCustomProperty**")
>   @JsonSubTypes({
>     @JsonSubTypes.Type(value = ClassA.class, name = "**typeA**"),
>     @JsonSubTypes.Type(value = ClassB.class, name = "**typeB**"),
>     @JsonSubTypes.Type(value = ClassC.class, name = "**typeC**")
>   })
>   public interface Item {

For more details see GeneratorResultTestJava.interfaceWithCustomDiscriminator test.

The CodegenModel in "swagger-codegen" also had to be changed, that PR must be merged first: [getSubTypeName() in CodegenModel](https://github.com/swagger-api/swagger-codegen/pull/12302)