### PR TITLE
read properties from allOf inline schemas

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/swift/Swift5Codegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/swift/Swift5Codegen.java
@@ -254,7 +254,7 @@ public class Swift5Codegen extends DefaultCodegenConfig {
         if (StringUtils.isBlank(templateDir)) {
             embeddedTemplateDir = templateDir = getTemplateDir();
         }
-        
+
         // Setup project name
         if (additionalProperties.containsKey(PROJECT_NAME)) {
             setProjectName((String) additionalProperties.get(PROJECT_NAME));
@@ -348,9 +348,6 @@ public class Swift5Codegen extends DefaultCodegenConfig {
         supportingFiles.add(new SupportingFile("gitignore.mustache",
             "",
             ".gitignore"));
-
-        copyFistAllOfProperties = true;
-
     }
 
     @Override
@@ -851,6 +848,11 @@ public class Swift5Codegen extends DefaultCodegenConfig {
             }
             codegenModel.vars = codegenProperties;
         }
+    }
+
+    @Override
+    protected boolean copyFirstAllOfProperties(Schema allOfSchema) {
+        return false;
     }
 }
 

--- a/src/main/resources/handlebars/Java/libraries/resteasy/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/resteasy/api.mustache
@@ -6,10 +6,10 @@ import {{invokerPackage}}.Configuration;
 import {{invokerPackage}}.Pair;
 
 {{#jakarta}}
-  import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.GenericType;
 {{/jakarta}}
 {{^jakarta}}
-  import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.GenericType;
 {{/jakarta}}
 
 {{#imports}}import {{import}};

--- a/src/main/resources/handlebars/Java/typeInfoAnnotation.mustache
+++ b/src/main/resources/handlebars/Java/typeInfoAnnotation.mustache
@@ -1,14 +1,14 @@
 {{#jackson}}
-  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{discriminator.propertyName}}", visible = true )
-  @JsonSubTypes({
-  {{#if discriminator.mapping}}
-    {{#each discriminator.mapping}}
-      @JsonSubTypes.Type(value = {{this}}.class, name = "{{@key}}"),
-    {{/each}}
-  {{else}}
-    {{#children}}
-      @JsonSubTypes.Type(value = {{classname}}.class, name = "{{name}}"),
-    {{/children}}
-  {{/if}}
-  })
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{discriminator.propertyName}}", visible = true )
+@JsonSubTypes({
+{{#if discriminator.mapping}}
+{{#each discriminator.mapping}}
+  @JsonSubTypes.Type(value = {{this}}.class, name = "{{@key}}"),
+{{/each}}
+{{else}}
+{{#children}}
+  @JsonSubTypes.Type(value = {{classname}}.class, name = "{{name}}"),
+{{/children}}
+{{/if}}
+})
 {{/jackson}}


### PR DESCRIPTION
fix https://github.com/swagger-api/swagger-codegen/issues/12241

About this PR:
Inline schemas were not propertly read from an allOf composed schema. This was fixed in order that all properties declared in allOf schemas (inline and no inline) can be included in the output code.