### PR TITLE
use URLSearchParams instead of querystring

### DIFF
--- a/src/main/resources/handlebars/javascript/es6/ApiClient.mustache
+++ b/src/main/resources/handlebars/javascript/es6/ApiClient.mustache
@@ -1,6 +1,5 @@
 {{>licenseInfo}}
 import superagent from "superagent";
-import querystring from "querystring";
 
 {{#emitJSDoc}}/**
 * @module {{#invokerPackage}}{{invokerPackage}}/{{/invokerPackage}}ApiClient
@@ -420,7 +419,7 @@ export class ApiClient {
         }
 
         if (contentType === 'application/x-www-form-urlencoded') {
-            request.send(querystring.stringify(this.normalizeParams(formParams)));
+            request.send(new URLSearchParams(this.normalizeParams(formParams)));
         } else if (contentType == 'multipart/form-data') {
             var _formParams = this.normalizeParams(formParams);
             for (var key in _formParams) {


### PR DESCRIPTION
`querystring` is deprecated, so it's removed from template and use URLSearchParams.