### PR TITLE
Fix for Markdown and HTML content in query parameter descriptions

### DIFF
--- a/src/main/resources/handlebars/htmlDocs/queryParam.mustache
+++ b/src/main/resources/handlebars/htmlDocs/queryParam.mustache
@@ -1,3 +1,3 @@
 {{#is this 'query-param'}}<div class="param">{{baseName}} {{^required}}(optional){{/required}}{{#required}}(required){{/required}}</div>
 
-      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; {{unescapedDescription}} {{#defaultValue}}default: {{{defaultValue}}} {{/defaultValue}}{{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>{{/is}}
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; {{{unescapedDescription}}} {{#defaultValue}}default: {{{defaultValue}}} {{/defaultValue}}{{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>{{/is}}


### PR DESCRIPTION
Without this change, HTML syntax in query param descriptions was escaped.
I 