### PR TITLE
Allow using Accept header passed as parameter

### DIFF
--- a/src/main/resources/handlebars/typescript-angular/api.service.mustache
+++ b/src/main/resources/handlebars/typescript-angular/api.service.mustache
@@ -248,7 +248,7 @@ export class {{classname}} {
             {{/produces}}
         ];
         const httpHeaderAcceptSelected: string | undefined = this.configuration.selectHeaderAccept(httpHeaderAccepts);
-        if (httpHeaderAcceptSelected != undefined) {
+        if ((httpHeaderAcceptSelected != undefined) && (headers.get('Accept') == undefined)) {
 {{^useHttpClient}}
             headers.set('Accept', httpHeaderAcceptSelected);
 {{/useHttpClient}}


### PR DESCRIPTION
Hi 
The Accept header that is passed as a parameter to the function was overridden by the default defined values.

Best regards,