### PR TITLE
Fixed copy/paste error in Java Oauth generator

### DIFF
--- a/src/main/resources/handlebars/Java/libraries/retrofit2/auth/OAuth.mustache
+++ b/src/main/resources/handlebars/Java/libraries/retrofit2/auth/OAuth.mustache
@@ -113,7 +113,6 @@ public class OAuth implements Interceptor {
 
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
             if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
-                if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 try {
                     if (updateAccessToken(requestAccessToken)) {
                         response.body().close();


### PR DESCRIPTION
Looks like bug was introduced in this commit, where the if statement was accidentally included in the second file of the PR:

https://github.com/swagger-api/swagger-codegen-generators/pull/1235/files#