### PR TITLE
Fix discriminator property name and mapping $ref value

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -1387,18 +1387,18 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
                     }
                 }
                 if (codegenModel.discriminator != null && codegenModel.discriminator.getPropertyName() != null) {
-                    codegenModel.discriminator.setPropertyName(toVarName(codegenModel.discriminator.getPropertyName()));
+                    codegenModel.discriminator.setPropertyName(codegenModel.discriminator.getPropertyName());
                     Map<String, String> classnameKeys = new HashMap<>();
 
                     if (composed.getOneOf()!=null) {
                         composed.getOneOf().forEach( s -> {
-                            codegenModel.discriminator.getMapping().keySet().stream().filter( key -> codegenModel.discriminator.getMapping().get(key).equals(s.get$ref()))
+                            codegenModel.discriminator.getMapping().keySet().stream().filter(key -> codegenModel.discriminator.getMapping().get(key).equals(s.get$ref()))
                                 .forEach(key -> {
                                     String mappingValue = codegenModel.discriminator.getMapping().get(key);
                                     if (classnameKeys.containsKey(codegenModel.classname)) {
                                         throw new IllegalArgumentException("Duplicate shema name in discriminator mapping");
                                     }
-                                    classnameKeys.put(toModelName(mappingValue.replace("#/components/schemas/", "")),key);
+                                    classnameKeys.put(key, toModelName(mappingValue.replace("#/components/schemas/", "")));
                                 });
                         });
                         codegenModel.discriminator.getMapping().putAll(classnameKeys);


### PR DESCRIPTION
The discriminator property name should not be camel-cased, and the key-value pair of discriminator mappings map is reversed in latest code.

For example,  this one-of definition would generate wrong java model interface as follows.
```yaml
NewDeployment:
  oneOf:
    - $ref: '#/components/schemas/MappingDeployment'
  discriminator:
    propertyName: deployment_type
    mapping:
      mapping_deployment: '#/components/schemas/MappingDeployment'
```

Java model interface generated
```java
@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "deploymentType", visible = true )
@JsonSubTypes({
    @JsonSubTypes.Type(value = #/components/schemas/MappingDeployment.class, name = "mapping_deployment"),
    @JsonSubTypes.Type(value = mapping_deployment.class, name = "MappingDeployment"),
})
public interface NewDeployment {
}
```

After fix, it would be
```java
@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "deployment_type", visible = true )
@JsonSubTypes({
    @JsonSubTypes.Type(value = MappingDeployment.class, name = "mapping_deployment"),
})
public interface NewDeployment {
}
```