### PR TITLE
Override toRegularExpression in AbstractKotlinCodegen so that there are no additional forward slashes generated on a (regex)pattern

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -1618,6 +1618,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         this.supportJava6 = value;
     }
 
+    @Override
     public String toRegularExpression(String pattern) {
         return escapeText(pattern);
     }

--- a/src/main/java/io/swagger/codegen/v3/generators/kotlin/AbstractKotlinCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/kotlin/AbstractKotlinCodegen.java
@@ -523,6 +523,11 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegenConfig {
         handlebars.registerHelpers(ConditionalHelpers.class);
     }
 
+    @Override
+    public String toRegularExpression(String pattern) {
+        return escapeText(pattern);
+    }
+
     /**
      * Provides a strongly typed declaration for simple arrays of some type and arrays of arrays of some type.
      *


### PR DESCRIPTION
Fixes [issue 1288](https://github.com/swagger-api/swagger-codegen-generators/issues/1288)