### PR TITLE
Add Csharp handlebar helper to capitalize string

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/handlebars/csharp/CsharpHelper.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/handlebars/csharp/CsharpHelper.java
@@ -6,7 +6,7 @@ public class CsharpHelper {
         return "\\";
     }
 
-    public String capitalize(String string){
-        return string.substring(0, 1).toUpperCase() + string.substring(1).toLowerCase();
+    public String capitalize(String str){
+        return str.substring(0, 1).toUpperCase() + str.substring(1).toLowerCase();
     }
 }

--- a/src/main/java/io/swagger/codegen/v3/generators/handlebars/csharp/CsharpHelper.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/handlebars/csharp/CsharpHelper.java
@@ -5,4 +5,8 @@ public class CsharpHelper {
     public CharSequence backslash() {
         return "\\";
     }
+
+    public String capitalize(String string){
+        return string.substring(0, 1).toUpperCase() + string.substring(1).toLowerCase();
+    }
 }


### PR DESCRIPTION
This helper will make converting Http methods names from uppercase to capitalized version possible: Method.GET -> Method.Get, which is supported by newest RestSharp version