### PR TITLE
[Java][Client] Fix Deprecated annotation of deprecated operations

### DIFF
--- a/src/main/resources/handlebars/Java/api.mustache
+++ b/src/main/resources/handlebars/Java/api.mustache
@@ -51,17 +51,17 @@ public class {{classname}} {
    * @return {{returnType}}
    {{/returnType}}
    * @throws ApiException if fails to make API call
-   {{#isDeprecated}}
+   {{#vendorExtensions.x-is-deprecated}}
    * @deprecated
-   {{/isDeprecated}}
+   {{/vendorExtensions.x-is-deprecated}}
    {{#externalDocs}}
    * {{description}}
    * @see <a href="{{url}}">{{summary}} Documentation</a>
    {{/externalDocs}}
    */
-  {{#isDeprecated}}
+  {{#vendorExtensions.x-is-deprecated}}
   @Deprecated
-  {{/isDeprecated}}
+  {{/vendorExtensions.x-is-deprecated}}
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#parameters}}{{{dataType}}} {{paramName}}{{#has this 'more'}}, {{/has}}{{/parameters}}) throws ApiException {
     Object {{localVariablePrefix}}localVarPostBody = {{^isForm}}{{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}{{/isForm}}{{#isForm}}null{{/isForm}};
     {{#parameters}}{{#required}}

--- a/src/main/resources/handlebars/Java/libraries/feign/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/feign/api.mustache
@@ -32,11 +32,17 @@ public interface {{classname}} extends ApiClient.Api {
    {{#returnType}}
    * @return {{returnType}}
    {{/returnType}}
+   {{#vendorExtensions.x-is-deprecated}}
+   * @deprecated
+   {{/vendorExtensions.x-is-deprecated}}
    {{#externalDocs}}
    * {{description}}
    * @see <a href="{{url}}">{{summary}} Documentation</a>
    {{/externalDocs}}
    */
+  {{#vendorExtensions.x-is-deprecated}}
+  @Deprecated
+  {{/vendorExtensions.x-is-deprecated}}
   @RequestLine("{{httpMethod}} {{{path}}}{{#hasQueryParams}}?{{/hasQueryParams}}{{#queryParams}}{{baseName}}={{braces "left"}}{{paramName}}{{braces "right"}}{{#has this 'more'}}&{{/has}}{{/queryParams}}")
   @Headers({
   {{#vendorExtensions.x-contentType}}
@@ -78,10 +84,16 @@ public interface {{classname}} extends ApiClient.Api {
    {{#returnType}}
    * @return {{returnType}}
    {{/returnType}}
+   {{#vendorExtensions.x-is-deprecated}}
+   * @deprecated
+   {{/vendorExtensions.x-is-deprecated}}
    {{#externalDocs}}
    * {{description}}
    * @see <a href="{{url}}">{{summary}} Documentation</a>{{/externalDocs}}
    */
+  {{#vendorExtensions.x-is-deprecated}}
+  @Deprecated
+  {{/vendorExtensions.x-is-deprecated}}
   @RequestLine("{{httpMethod}} {{{path}}}?{{#queryParams}}{{baseName}}={{braces "left"}}{{paramName}}{{braces "right"}}{{#has this 'more'}}&{{/has}}{{/queryParams}}")
   @Headers({
   {{#vendorExtensions.x-contentType}}

--- a/src/main/resources/handlebars/Java/libraries/jersey2/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/jersey2/api.mustache
@@ -55,17 +55,17 @@ public class {{classname}} {
    * @return {{returnType}}
    {{/returnType}}
    * @throws ApiException if fails to make API call
-   {{#isDeprecated}}
+   {{#vendorExtensions.x-is-deprecated}}
    * @deprecated
-   {{/isDeprecated}}
+   {{/vendorExtensions.x-is-deprecated}}
    {{#externalDocs}}
    * {{description}}
    * @see <a href="{{url}}">{{summary}} Documentation</a>
    {{/externalDocs}}
    */
-  {{#isDeprecated}}
+  {{#vendorExtensions.x-is-deprecated}}
   @Deprecated
-  {{/isDeprecated}}
+  {{/vendorExtensions.x-is-deprecated}}
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#parameters}}{{{dataType}}} {{paramName}}{{#has this 'more'}}, {{/has}}{{/parameters}}) throws ApiException {
     Object {{localVariablePrefix}}localVarPostBody = {{^isForm}}{{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}{{/isForm}}{{#isForm}}null{{/isForm}};
     {{#parameters}}

--- a/src/main/resources/handlebars/Java/libraries/jersey3/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/jersey3/api.mustache
@@ -48,17 +48,17 @@ public class {{classname}} {
      * @return {{returnType}}
     {{/returnType}}
      * @throws ApiException if fails to make API call
-    {{#isDeprecated}}
+    {{#vendorExtensions.x-is-deprecated}}
      * @deprecated
-    {{/isDeprecated}}
+    {{/vendorExtensions.x-is-deprecated}}
     {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
     {{/externalDocs}}
      */
-    {{#isDeprecated}}
+    {{#vendorExtensions.x-is-deprecated}}
     @Deprecated
-    {{/isDeprecated}}
+    {{/vendorExtensions.x-is-deprecated}}
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#parameters}}{{{dataType}}} {{paramName}}{{#has this 'more'}}, {{/has}}{{/parameters}}) throws ApiException {
         Object {{localVariablePrefix}}localVarPostBody = {{^isForm}}{{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}{{/isForm}}{{#isForm}}null{{/isForm}};
         {{#parameters}}

--- a/src/main/resources/handlebars/Java/libraries/okhttp-gson/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/okhttp-gson/api.mustache
@@ -84,11 +84,17 @@ public class {{classname}} {
      * @param progressRequestListener Progress request listener
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
-        {{#externalDocs}}
+     {{#vendorExtensions.x-is-deprecated}}
+     * @deprecated
+     {{/vendorExtensions.x-is-deprecated}}
+     {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
-        {{/externalDocs}}
+     {{/externalDocs}}
      */
+    {{#vendorExtensions.x-is-deprecated}}
+    @Deprecated
+    {{/vendorExtensions.x-is-deprecated}}
     public com.squareup.okhttp.Call {{operationId}}Call({{#parameters}}{{{dataType}}} {{paramName}}, {{/parameters}}final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object {{localVariablePrefix}}localVarPostBody = {{^isForm}}{{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}{{/isForm}}{{#isForm}}null{{/isForm}};
         
@@ -193,11 +199,17 @@ public class {{classname}} {
      * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/parameters}}{{#returnType}}
      * @return {{returnType}}{{/returnType}}
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-        {{#externalDocs}}
+     {{#vendorExtensions.x-is-deprecated}}
+     * @deprecated
+     {{/vendorExtensions.x-is-deprecated}}
+     {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
-        {{/externalDocs}}
+     {{/externalDocs}}
      */
+    {{#vendorExtensions.x-is-deprecated}}
+    @Deprecated
+    {{/vendorExtensions.x-is-deprecated}}
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#parameters}}{{{dataType}}} {{paramName}}{{#has this 'more'}}, {{/has}}{{/parameters}}) throws ApiException {
         {{#returnType}}ApiResponse<{{{returnType}}}> {{localVariablePrefix}}resp = {{/returnType}}{{operationId}}WithHttpInfo({{#parameters}}{{paramName}}{{#has this 'more'}}, {{/has}}{{/parameters}});{{#returnType}}
         return {{localVariablePrefix}}resp.getData();{{/returnType}}
@@ -209,11 +221,17 @@ public class {{classname}} {
      * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/parameters}}
      * @return ApiResponse&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Void{{/returnType}}&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-        {{#externalDocs}}
+     {{#vendorExtensions.x-is-deprecated}}
+     * @deprecated
+     {{/vendorExtensions.x-is-deprecated}}
+     {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
-        {{/externalDocs}}
+     {{/externalDocs}}
      */
+    {{#vendorExtensions.x-is-deprecated}}
+    @Deprecated
+    {{/vendorExtensions.x-is-deprecated}}
     public ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#parameters}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{{dataType}}} {{paramName}}{{#has this 'more'}}, {{/has}}{{/parameters}}) throws ApiException {
         com.squareup.okhttp.Call {{localVariablePrefix}}call = {{operationId}}ValidateBeforeCall({{#parameters}}{{paramName}}, {{/parameters}}null, null);
         {{#returnType}}Type {{localVariablePrefix}}localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
@@ -227,11 +245,17 @@ public class {{classname}} {
      * @param callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
-        {{#externalDocs}}
+     {{#vendorExtensions.x-is-deprecated}}
+     * @deprecated
+     {{/vendorExtensions.x-is-deprecated}}
+     {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
-        {{/externalDocs}}
+     {{/externalDocs}}
      */
+    {{#vendorExtensions.x-is-deprecated}}
+    @Deprecated
+    {{/vendorExtensions.x-is-deprecated}}
     public com.squareup.okhttp.Call {{operationId}}Async({{#parameters}}{{{dataType}}} {{paramName}}, {{/parameters}}final ApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{localVariablePrefix}}callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;

--- a/src/main/resources/handlebars/Java/libraries/okhttp4-gson/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/okhttp4-gson/api.mustache
@@ -71,11 +71,17 @@ public class {{classname}} {
      * @param progressRequestListener Progress request listener
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
-        {{#externalDocs}}
+     {{#vendorExtensions.x-is-deprecated}}
+     * @deprecated
+     {{/vendorExtensions.x-is-deprecated}}
+     {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
-        {{/externalDocs}}
+     {{/externalDocs}}
      */
+    {{#vendorExtensions.x-is-deprecated}}
+    @Deprecated
+    {{/vendorExtensions.x-is-deprecated}}
     public okhttp3.Call {{operationId}}Call({{#parameters}}{{{dataType}}} {{paramName}}, {{/parameters}}final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object {{localVariablePrefix}}localVarPostBody = {{^isForm}}{{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}{{/isForm}}{{#isForm}}null{{/isForm}};
 
@@ -128,9 +134,6 @@ public class {{classname}} {
         return {{localVariablePrefix}}apiClient.buildCall({{localVariablePrefix}}localVarPath, "{{httpMethod}}", {{localVariablePrefix}}localVarQueryParams, {{localVariablePrefix}}localVarCollectionQueryParams, {{localVariablePrefix}}localVarPostBody, {{localVariablePrefix}}localVarHeaderParams, {{localVariablePrefix}}localVarFormParams, {{localVariablePrefix}}localVarAuthNames, progressRequestListener);
     }
 
-    {{#isDeprecated}}
-    @Deprecated
-    {{/isDeprecated}}
     @SuppressWarnings("rawtypes")
     private okhttp3.Call {{operationId}}ValidateBeforeCall({{#parameters}}{{{dataType}}} {{paramName}}, {{/parameters}}final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         {{^performBeanValidation}}
@@ -179,11 +182,17 @@ public class {{classname}} {
      * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/parameters}}{{#returnType}}
      * @return {{returnType}}{{/returnType}}
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-        {{#externalDocs}}
+     {{#vendorExtensions.x-is-deprecated}}
+     * @deprecated
+     {{/vendorExtensions.x-is-deprecated}}
+     {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
-        {{/externalDocs}}
+     {{/externalDocs}}
      */
+    {{#vendorExtensions.x-is-deprecated}}
+    @Deprecated
+    {{/vendorExtensions.x-is-deprecated}}
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#parameters}}{{{dataType}}} {{paramName}}{{#has this 'more'}}, {{/has}}{{/parameters}}) throws ApiException {
         {{#returnType}}ApiResponse<{{{returnType}}}> {{localVariablePrefix}}resp = {{/returnType}}{{operationId}}WithHttpInfo({{#parameters}}{{paramName}}{{#has this 'more'}}, {{/has}}{{/parameters}});{{#returnType}}
         return {{localVariablePrefix}}resp.getData();{{/returnType}}
@@ -195,11 +204,17 @@ public class {{classname}} {
      * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/parameters}}
      * @return ApiResponse&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Void{{/returnType}}&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
-        {{#externalDocs}}
+     {{#vendorExtensions.x-is-deprecated}}
+     * @deprecated
+     {{/vendorExtensions.x-is-deprecated}}
+     {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
-        {{/externalDocs}}
+     {{/externalDocs}}
      */
+    {{#vendorExtensions.x-is-deprecated}}
+    @Deprecated
+    {{/vendorExtensions.x-is-deprecated}}
     public ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#parameters}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{{dataType}}} {{paramName}}{{#has this 'more'}}, {{/has}}{{/parameters}}) throws ApiException {
         okhttp3.Call {{localVariablePrefix}}call = {{operationId}}ValidateBeforeCall({{#parameters}}{{paramName}}, {{/parameters}}null, null);
         {{#returnType}}Type {{localVariablePrefix}}localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
@@ -213,11 +228,17 @@ public class {{classname}} {
      * @param callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
-        {{#externalDocs}}
+     {{#vendorExtensions.x-is-deprecated}}
+     * @deprecated
+     {{/vendorExtensions.x-is-deprecated}}
+     {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
-        {{/externalDocs}}
+     {{/externalDocs}}
      */
+    {{#vendorExtensions.x-is-deprecated}}
+    @Deprecated
+    {{/vendorExtensions.x-is-deprecated}}
     public okhttp3.Call {{operationId}}Async({{#parameters}}{{{dataType}}} {{paramName}}, {{/parameters}}final ApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{localVariablePrefix}}callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;

--- a/src/main/resources/handlebars/Java/libraries/resteasy/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/resteasy/api.mustache
@@ -51,17 +51,17 @@ public class {{classname}} {
    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/parameters}}{{#returnType}}
    * @return {{{returnType}}}{{/returnType}}
    * @throws ApiException if fails to make API call
-   {{#isDeprecated}}
+   {{#vendorExtension.x-is-enum}}
    * @deprecated
-   {{/isDeprecated}}
+   {{/vendorExtension.x-is-enum}}
    {{#externalDocs}}
    * {{description}}
    * @see <a href="{{url}}">{{summary}} Documentation</a>
    {{/externalDocs}}
    */
-  {{#isDeprecated}}
+  {{#vendorExtension.x-is-enum}}
   @Deprecated
-  {{/isDeprecated}}
+  {{/vendorExtension.x-is-enum}}
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#parameters}}{{{dataType}}} {{paramName}}{{#has this 'more'}}, {{/has}}{{/parameters}}) throws ApiException {
     Object {{localVariablePrefix}}localVarPostBody = {{^isForm}}{{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}{{/isForm}}{{#isForm}}null{{/isForm}};
     {{#parameters}}{{#required}}

--- a/src/main/resources/handlebars/Java/libraries/resttemplate/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/resttemplate/api.mustache
@@ -63,14 +63,17 @@ public class {{classname}} {
      * @return {{returnType}}
     {{/returnType}}
      * @throws RestClientException if an error occurs while attempting to invoke the API
+    {{#vendorExtensions.x-is-deprecated}}
+    * @deprecated
+    {{/vendorExtensions.x-is-deprecated}}
     {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
     {{/externalDocs}}
      */
-    {{#isDeprecated}}
+    {{#vendorExtension.x-is-enum}}
     @Deprecated
-    {{/isDeprecated}}
+    {{/vendorExtension.x-is-enum}}
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#parameters}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/parameters}}) throws RestClientException {
         {{#returnType}}
         return {{operationId}}WithHttpInfo({{#parameters}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/parameters}}).getBody();
@@ -91,14 +94,17 @@ public class {{classname}} {
      {{/parameters}}
      * @return ResponseEntity&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Void{{/returnType}}&gt;
      * @throws RestClientException if an error occurs while attempting to invoke the API
+     {{#vendorExtensions.x-is-deprecated}}
+     * @deprecated
+     {{/vendorExtensions.x-is-deprecated}}
      {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
      {{/externalDocs}}
      */
-    {{#isDeprecated}}
+    {{#vendorExtension.x-is-enum}}
     @Deprecated
-    {{/isDeprecated}}
+    {{/vendorExtension.x-is-enum}}
     public ResponseEntity<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#parameters}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/parameters}}) throws RestClientException {
         Object {{localVariablePrefix}}postBody = {{^isForm}}{{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}{{/isForm}}{{#isForm}}null{{/isForm}};
         {{#parameters}}

--- a/src/main/resources/handlebars/Java/libraries/retrofit/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/retrofit/api.mustache
@@ -56,6 +56,9 @@ public interface {{classname}} {
    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/parameters}}
    * @param cb callback method
+{{#vendorExtensions.x-is-deprecated}}
+   * @deprecated
+{{/vendorExtensions.x-is-deprecated}}
 {{#externalDocs}}
    * {{description}}
    * @see <a href="{{url}}">{{summary}} Documentation</a>
@@ -72,6 +75,9 @@ public interface {{classname}} {
   {{/@first}}
   {{/formParams}}
   @{{httpMethod}}("{{{path}}}")
+  {{#vendorExtensions.x-is-deprecated}}
+  @Deprecated
+  {{/vendorExtensions.x-is-deprecated}}
   void {{operationId}}(
     {{#parameters}}{{>libraries/retrofit/queryParams}}{{>libraries/retrofit/pathParams}}{{>libraries/retrofit/headerParams}}{{>libraries/retrofit/bodyParams}}{{>libraries/retrofit/formParams}}{{>libraries/retrofit/cookieParams}}, {{/parameters}}Callback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Object{{/returnType}}> cb
   );

--- a/src/main/resources/handlebars/Java/libraries/retrofit2/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/retrofit2/api.mustache
@@ -40,11 +40,17 @@ public interface {{classname}} {
    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/parameters}}
    * @return Call&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Object{{/returnType}}&gt;
+{{#vendorExtensions.x-is-deprecated}}
+   * @deprecated
+{{/vendorExtensions.x-is-deprecated}}
 {{#externalDocs}}
    * {{description}}
    * @see <a href="{{url}}">{{summary}} Documentation</a>
 {{/externalDocs}}
    */
+  {{#vendorExtensions.x-is-deprecated}}
+  @Deprecated
+  {{/vendorExtensions.x-is-deprecated}}
   {{#formParams}}
   {{#@first}}
   {{#is ../this 'multipart'}}@retrofit2.http.Multipart{{/is}}{{#isNot ../this 'multipart'}}@retrofit2.http.FormUrlEncoded{{/isNot}}

--- a/src/main/resources/handlebars/Java/libraries/retrofit2/play24/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/retrofit2/play24/api.mustache
@@ -33,7 +33,13 @@ public interface {{classname}} {
    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/parameters}}
    * @return Call&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Object{{/returnType}}&gt;
+{{#vendorExtensions.x-is-deprecated}}
+   * @deprecated
+{{/vendorExtensions.x-is-deprecated}}
    */
+  {{#vendorExtensions.x-is-deprecated}}
+  @Deprecated
+  {{/vendorExtensions.x-is-deprecated}}
   {{#formParams}}
   {{#@first}}
   {{#isMultipart}}@retrofit2.http.Multipart{{/isMultipart}}{{^isMultipart}}@retrofit2.http.FormUrlEncoded{{/isMultipart}}

--- a/src/main/resources/handlebars/Java/libraries/retrofit2/play25/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/retrofit2/play25/api.mustache
@@ -33,7 +33,13 @@ public interface {{classname}} {
    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/parameters}}
    * @return Call&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Void{{/returnType}}&gt;
+{{#vendorExtensions.x-is-deprecated}}
+   * @deprecated
+{{/vendorExtensions.x-is-deprecated}}
    */
+  {{#vendorExtensions.x-is-deprecated}}
+  @Deprecated
+  {{/vendorExtensions.x-is-deprecated}}
   {{#formParams}}
   {{#@first}}
   {{#isMultipart}}@retrofit2.http.Multipart{{/isMultipart}}{{^isMultipart}}@retrofit2.http.FormUrlEncoded{{/isMultipart}}


### PR DESCRIPTION
There was:
- a PR: https://github.com/swagger-api/swagger-codegen/pull/6166
- and a Fix: https://github.com/swagger-api/swagger-codegen/pull/6801 .
Those add the `@Deprecated` annotation to deprecated operations and the `@deprecated` javadoc annotation to their javadoc comments.

Then there was the [migration](https://github.com/swagger-api/swagger-codegen/wiki/Swagger-Codegen-migration-from-Mustache-and-Handlebars-templates.#:~:text=The%20main%20change%20that%20affects%20templates%20is%20that%20is*%2C%20isNot*%2C%20has*%2C%20hasNot*%20properties%20have%20been%20removed%20from%20codegen%20pojo%20(CodegenModel%2C%20CodegenProperty%2C%20etc)%20and%20replaced%20for%20extensions.%20So%20one%20option%20to%20access%20those%20values%20is%3A%20%7B%7B%23vendorExtension.x%2Dis%2Denum%7D%7D) that removed the `isDeprecated` property which lead to the annotations not being generated when needed. But the vendorExtension can be used instead, which I did.

