### PR TITLE
Fix #11899: Add ignoreUnknownJacksonAnnotation configuration property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.swagger.codegen.v3</groupId>
     <artifactId>swagger-codegen-generators</artifactId>
-    <version>1.0.52</version>
+    <version>1.0.53-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <build>

--- a/src/main/java/io/swagger/codegen/v3/generators/features/IgnoreUnknownJacksonFeatures.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/features/IgnoreUnknownJacksonFeatures.java
@@ -1,0 +1,10 @@
+package io.swagger.codegen.v3.generators.features;
+
+public interface IgnoreUnknownJacksonFeatures {
+    // Language supports generating JsonIgnoreProperties(ignoreUnknown = true)
+    String IGNORE_UNKNOWN_JACKSON_ANNOTATION = "ignoreUnknownJacksonAnnotation";
+
+    void setIgnoreUnknownJacksonAnnotation(boolean ignoreUnknownJacksonAnnotation);
+
+    boolean isIgnoreUnknownJacksonAnnotation();
+}

--- a/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/AbstractJavaCodegen.java
@@ -2,6 +2,7 @@ package io.swagger.codegen.v3.generators.java;
 
 import static io.swagger.codegen.v3.CodegenConstants.HAS_ENUMS_EXT_NAME;
 import static io.swagger.codegen.v3.CodegenConstants.IS_ENUM_EXT_NAME;
+import static io.swagger.codegen.v3.generators.features.IgnoreUnknownJacksonFeatures.IGNORE_UNKNOWN_JACKSON_ANNOTATION;
 import static io.swagger.codegen.v3.generators.features.NotNullAnnotationFeatures.NOT_NULL_JACKSON_ANNOTATION;
 import static io.swagger.codegen.v3.generators.handlebars.ExtensionHelper.getBooleanValue;
 
@@ -14,6 +15,7 @@ import io.swagger.codegen.v3.CodegenOperation;
 import io.swagger.codegen.v3.CodegenParameter;
 import io.swagger.codegen.v3.CodegenProperty;
 import io.swagger.codegen.v3.generators.DefaultCodegenConfig;
+import io.swagger.codegen.v3.generators.features.IgnoreUnknownJacksonFeatures;
 import io.swagger.codegen.v3.generators.features.NotNullAnnotationFeatures;
 import io.swagger.codegen.v3.generators.handlebars.java.JavaHelper;
 import io.swagger.codegen.v3.utils.URLPathUtil;
@@ -100,6 +102,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
     protected boolean jakarta = false;
     private NotNullAnnotationFeatures notNullOption;
     protected boolean useNullableForNotNull = true;
+    private IgnoreUnknownJacksonFeatures ignoreUnknown;
 
     public AbstractJavaCodegen() {
         super();
@@ -171,6 +174,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
         cliOptions.add(CliOption.newBoolean(CodegenConstants.USE_OAS2, CodegenConstants.USE_OAS2_DESC));
         if(this instanceof NotNullAnnotationFeatures){
             cliOptions.add(CliOption.newBoolean(NOT_NULL_JACKSON_ANNOTATION, "adds @JsonInclude(JsonInclude.Include.NON_NULL) annotation to model classes"));
+        }
+        if (this instanceof IgnoreUnknownJacksonFeatures){
+            cliOptions.add(CliOption.newBoolean(IGNORE_UNKNOWN_JACKSON_ANNOTATION,
+                "adds @JsonIgnoreProperties(ignoreUnknown = true) annotation to model classes"));
         }
         CliOption dateLibrary = new CliOption(DATE_LIBRARY, "Option. Date library to use");
         Map<String, String> dateOptions = new HashMap<String, String>();
@@ -390,6 +397,17 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
                 writePropertyBack(NOT_NULL_JACKSON_ANNOTATION, notNullOption.isNotNullJacksonAnnotation());
                 if (notNullOption.isNotNullJacksonAnnotation()) {
                     importMapping.put("JsonInclude", "com.fasterxml.jackson.annotation.JsonInclude");
+                }
+            }
+        }
+
+        if (this instanceof IgnoreUnknownJacksonFeatures) {
+            ignoreUnknown = (IgnoreUnknownJacksonFeatures)this;
+            if (additionalProperties.containsKey(IGNORE_UNKNOWN_JACKSON_ANNOTATION)) {
+                ignoreUnknown.setIgnoreUnknownJacksonAnnotation(convertPropertyToBoolean(IGNORE_UNKNOWN_JACKSON_ANNOTATION));
+                writePropertyBack(IGNORE_UNKNOWN_JACKSON_ANNOTATION, ignoreUnknown.isIgnoreUnknownJacksonAnnotation());
+                if (ignoreUnknown.isIgnoreUnknownJacksonAnnotation()) {
+                    importMapping.put("JsonIgnoreProperties", "com.fasterxml.jackson.annotation.JsonIgnoreProperties");
                 }
             }
         }
@@ -1004,6 +1022,16 @@ public abstract class AbstractJavaCodegen extends DefaultCodegenConfig {
                 if (additionalProperties.containsKey(NOT_NULL_JACKSON_ANNOTATION)) {
                     if (notNullOption.isNotNullJacksonAnnotation()) {
                         codegenModel.imports.add("JsonInclude");
+                    }
+                }
+            }
+        }
+        if (this instanceof IgnoreUnknownJacksonFeatures) {
+            if (this instanceof IgnoreUnknownJacksonFeatures) {
+                ignoreUnknown = (IgnoreUnknownJacksonFeatures)this;
+                if (additionalProperties.containsKey(IGNORE_UNKNOWN_JACKSON_ANNOTATION)) {
+                    if (ignoreUnknown.isIgnoreUnknownJacksonAnnotation()) {
+                        codegenModel.imports.add("JsonIgnoreProperties");
                     }
                 }
             }

--- a/src/main/java/io/swagger/codegen/v3/generators/java/JavaClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/JavaClientCodegen.java
@@ -10,6 +10,7 @@ import io.swagger.codegen.v3.CodegenType;
 import io.swagger.codegen.v3.SupportingFile;
 import io.swagger.codegen.v3.generators.features.BeanValidationFeatures;
 import io.swagger.codegen.v3.generators.features.GzipFeatures;
+import io.swagger.codegen.v3.generators.features.IgnoreUnknownJacksonFeatures;
 import io.swagger.codegen.v3.generators.features.NotNullAnnotationFeatures;
 import io.swagger.codegen.v3.generators.features.PerformBeanValidationFeatures;
 import io.swagger.codegen.v3.generators.util.OpenAPIUtil;
@@ -33,7 +34,7 @@ import static io.swagger.codegen.v3.CodegenConstants.IS_ENUM_EXT_NAME;
 import static io.swagger.codegen.v3.generators.handlebars.ExtensionHelper.getBooleanValue;
 import static java.util.Collections.sort;
 
-public class JavaClientCodegen extends AbstractJavaCodegen implements BeanValidationFeatures, PerformBeanValidationFeatures, GzipFeatures, NotNullAnnotationFeatures {
+public class JavaClientCodegen extends AbstractJavaCodegen implements BeanValidationFeatures, PerformBeanValidationFeatures, GzipFeatures, NotNullAnnotationFeatures, IgnoreUnknownJacksonFeatures {
     static final String MEDIA_TYPE = "mediaType";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JavaClientCodegen.class);
@@ -66,7 +67,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen implements BeanValida
     protected boolean useGzipFeature = false;
     protected boolean useRuntimeException = false;
     private boolean notNullJacksonAnnotation = false;
-
+    private boolean ignoreUnknownJacksonAnnotation = false;
 
     public JavaClientCodegen() {
         super();
@@ -640,5 +641,15 @@ public class JavaClientCodegen extends AbstractJavaCodegen implements BeanValida
     @Override
     public boolean isNotNullJacksonAnnotation() {
         return notNullJacksonAnnotation;
+    }
+
+    @Override
+    public void setIgnoreUnknownJacksonAnnotation(boolean ignoreUnknownJacksonAnnotation) {
+        this.ignoreUnknownJacksonAnnotation = ignoreUnknownJacksonAnnotation;
+    }
+
+    @Override
+    public boolean isIgnoreUnknownJacksonAnnotation() {
+        return ignoreUnknownJacksonAnnotation;
     }
 }

--- a/src/main/java/io/swagger/codegen/v3/generators/java/SpringCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/java/SpringCodegen.java
@@ -14,6 +14,7 @@ import io.swagger.codegen.v3.CodegenSecurity;
 import io.swagger.codegen.v3.CodegenType;
 import io.swagger.codegen.v3.SupportingFile;
 import io.swagger.codegen.v3.generators.features.BeanValidationFeatures;
+import io.swagger.codegen.v3.generators.features.IgnoreUnknownJacksonFeatures;
 import io.swagger.codegen.v3.generators.features.NotNullAnnotationFeatures;
 import io.swagger.codegen.v3.generators.features.OptionalFeatures;
 import io.swagger.codegen.v3.generators.util.OpenAPIUtil;
@@ -45,7 +46,7 @@ import static io.swagger.codegen.v3.CodegenConstants.HAS_ENUMS_EXT_NAME;
 import static io.swagger.codegen.v3.CodegenConstants.IS_ENUM_EXT_NAME;
 import static io.swagger.codegen.v3.generators.handlebars.ExtensionHelper.getBooleanValue;
 
-public class SpringCodegen extends AbstractJavaCodegen implements BeanValidationFeatures, OptionalFeatures, NotNullAnnotationFeatures {
+public class SpringCodegen extends AbstractJavaCodegen implements BeanValidationFeatures, OptionalFeatures, NotNullAnnotationFeatures, IgnoreUnknownJacksonFeatures {
     static Logger LOGGER = LoggerFactory.getLogger(SpringCodegen.class);
     public static final String DEFAULT_LIBRARY = "spring-boot";
     public static final String TITLE = "title";
@@ -98,6 +99,7 @@ public class SpringCodegen extends AbstractJavaCodegen implements BeanValidation
     protected boolean throwsException = false;
     private boolean notNullJacksonAnnotation = false;
     protected String validationMode = "strict";
+    private boolean ignoreUnknownJacksonAnnotation = false;
 
     public SpringCodegen() {
         super();
@@ -699,6 +701,16 @@ public class SpringCodegen extends AbstractJavaCodegen implements BeanValidation
     @Override
     public boolean isNotNullJacksonAnnotation() {
         return notNullJacksonAnnotation;
+    }
+
+    @Override
+    public void setIgnoreUnknownJacksonAnnotation(boolean ignoreUnknownJacksonAnnotation) {
+        this.ignoreUnknownJacksonAnnotation = ignoreUnknownJacksonAnnotation;
+    }
+
+    @Override
+    public boolean isIgnoreUnknownJacksonAnnotation() {
+        return ignoreUnknownJacksonAnnotation;
     }
 
     private interface DataTypeAssigner {

--- a/src/main/resources/handlebars/Java/libraries/okhttp-gson/pom.mustache
+++ b/src/main/resources/handlebars/Java/libraries/okhttp-gson/pom.mustache
@@ -206,6 +206,13 @@
               <version>2.10.1</version>
           </dependency>
       {{/notNullJacksonAnnotation}}
+      {{#ignoreUnknownJacksonAnnotation}}
+          <dependency>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-annotations</artifactId>
+              <version>2.10.1</version>
+          </dependency>
+      {{/ignoreUnknownJacksonAnnotation}}
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp</artifactId>

--- a/src/main/resources/handlebars/Java/pojo.mustache
+++ b/src/main/resources/handlebars/Java/pojo.mustache
@@ -6,7 +6,9 @@
 {{#notNullJacksonAnnotation}}
 @JsonInclude(JsonInclude.Include.NON_NULL)
 {{/notNullJacksonAnnotation}}
-
+{{#ignoreUnknownJacksonAnnotation}}
+@JsonIgnoreProperties(ignoreUnknown = true)
+{{/ignoreUnknownJacksonAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcelableModel}}implements Parcelable {{#serializableModel}}, Serializable {{/serializableModel}}{{#interfaceModels}}{{#@first}}, {{/@first}}{{classname}}{{^@last}}, {{/@last}}{{#@last}} {{/@last}}{{/interfaceModels}}{{/parcelableModel}}{{^parcelableModel}}{{#serializableModel}}implements Serializable{{#interfaceModels}}{{#@first}}, {{/@first}}{{classname}}{{^@last}}, {{/@last}}{{#@last}} {{/@last}}{{/interfaceModels}}{{/serializableModel}}{{^serializableModel}}{{#interfaceModels}}{{#@first}}implements {{/@first}}{{classname}}{{^@last}}, {{/@last}}{{#@last}} {{/@last}}{{/interfaceModels}}{{/serializableModel}}{{/parcelableModel}}{
 {{#serializableModel}}
   private static final long serialVersionUID = 1L;

--- a/src/main/resources/handlebars/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/src/main/resources/handlebars/JavaSpring/libraries/spring-boot/pom.mustache
@@ -155,7 +155,13 @@
                 <version>2.10.1</version>
             </dependency>
         {{/notNullJacksonAnnotation}}
-
+        {{#ignoreUnknownJacksonAnnotation}}
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.10.1</version>
+            </dependency>
+        {{/ignoreUnknownJacksonAnnotation}}
         {{^useOas2}}
         <dependency>
             <groupId>org.springframework.plugin</groupId>

--- a/src/main/resources/handlebars/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/src/main/resources/handlebars/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -154,7 +154,13 @@
                 <version>2.10.1</version>
             </dependency>
         {{/notNullJacksonAnnotation}}
-
+        {{#ignoreUnknownJacksonAnnotation}}
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.10.1</version>
+            </dependency>
+        {{/ignoreUnknownJacksonAnnotation}}
 {{#jakarta}}
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/src/main/resources/handlebars/JavaSpring/libraries/spring-mvc/pom.mustache
+++ b/src/main/resources/handlebars/JavaSpring/libraries/spring-mvc/pom.mustache
@@ -247,6 +247,13 @@
                 <version>${jackson-version}</version>
             </dependency>
         {{/notNullJacksonAnnotation}}
+        {{#ignoreUnknownJacksonAnnotation}}
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson-version}</version>
+            </dependency>
+        {{/ignoreUnknownJacksonAnnotation}}
     <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>

--- a/src/main/resources/handlebars/JavaSpring/pojo.mustache
+++ b/src/main/resources/handlebars/JavaSpring/pojo.mustache
@@ -6,7 +6,7 @@
 {{#useBeanValidation}}{{#isStrictValidation}}@NotUndefined{{/isStrictValidation}}{{#isLooseValidation}}@NotUndefined{{/isLooseValidation}}{{/useBeanValidation}}
 {{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#notNullJacksonAnnotation}}@JsonInclude(JsonInclude.Include.NON_NULL){{/notNullJacksonAnnotation}}
-
+{{#ignoreUnknownJacksonAnnotation}}@JsonIgnoreProperties(ignoreUnknown = true){{/ignoreUnknownJacksonAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable {{#interfaceModels}}, {{classname}}{{^@last}}, {{/@last}}{{#@last}} {{/@last}}{{/interfaceModels}}{{/serializableModel}}{{^serializableModel}}{{#interfaceModels}}{{#@first}}implements {{/@first}}{{classname}}{{^@last}}, {{/@last}}{{#@last}}{{/@last}}{{/interfaceModels}}{{/serializableModel}} {
 {{#serializableModel}}
   private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Support ignoreUnknownJacksonAnnotation to support the addition of `@JsonIgnoreProperties(ignoreUnknown = true)` during code generation