### PR TITLE
Spring - fix jakarta imports for validation-mode 'strict'

### DIFF
--- a/src/main/resources/handlebars/JavaSpring/NotUndefined.mustache
+++ b/src/main/resources/handlebars/JavaSpring/NotUndefined.mustache
@@ -1,7 +1,13 @@
 package {{configPackage}};
 
+{{#jakarta}}
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+{{/jakarta}}
+{{^jakarta}}
 import javax.validation.Constraint;
 import javax.validation.Payload;
+{{/jakarta}}
 import java.lang.annotation.*;
 
 @Target({ElementType.TYPE})

--- a/src/main/resources/handlebars/JavaSpring/NotUndefinedValidator.mustache
+++ b/src/main/resources/handlebars/JavaSpring/NotUndefinedValidator.mustache
@@ -1,8 +1,14 @@
 package {{configPackage}};
 
 import org.openapitools.jackson.nullable.JsonNullable;
+{{#jakarta}}
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+{{/jakarta}}
+{{^jakarta}}
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+{{/jakarta}}
 import java.lang.reflect.Field;
 
 public class NotUndefinedValidator implements ConstraintValidator<NotUndefined, Object>{

--- a/src/test/java/io/swagger/codegen/v3/generators/java/SpringGeneratorTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/SpringGeneratorTest.java
@@ -16,6 +16,8 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.List;
 
+import static org.testng.Assert.*;
+
 public class SpringGeneratorTest extends AbstractCodegenTest {
     @Test
     public void testGenerator() throws Exception {
@@ -37,12 +39,13 @@ public class SpringGeneratorTest extends AbstractCodegenTest {
                     // .addAdditionalProperty("validationMode", "legacyNullable")
                     // .addAdditionalProperty("useBeanValidation", false)
                     // .addAdditionalProperty("useNullableForNotNull", false)
+                    .addAdditionalProperty("jakarta", true)
                     .outputDir(path)
             );
 
         List<File> files = new GeneratorService().generationRequest(request).generate();
         Assert.assertFalse(files.isEmpty());
-/*        for (File f: files) {
+        for (File f: files) {
             // test stuff
             if (f.getName().endsWith("Pet.java")) {
                 String content = new String(Files.readAllBytes(f.toPath()));
@@ -60,7 +63,17 @@ public class SpringGeneratorTest extends AbstractCodegenTest {
                 String content = new String(Files.readAllBytes(f.toPath()));
                 // System.out.println(content);
             }
-        }*/
+            if (f.getName().endsWith("NotUndefined.java")) {
+                String content = new String(Files.readAllBytes(f.toPath()));
+                assertNotNull(content);
+                assertFalse(content.contains("import javax.validation"));
+            }
+            if (f.getName().endsWith("NotUndefinedValidator.java")) {
+                String content = new String(Files.readAllBytes(f.toPath()));
+                assertNotNull(content);
+                assertFalse(content.contains("import javax.validation"));
+            }
+        }
     }
 
     protected static File getTmpFolder() {


### PR DESCRIPTION
This PR directly addresses commit 2835d9de which was added in https://github.com/swagger-api/swagger-codegen-generators/pull/1308 :
When configuring the generator to use imports from the jakarta-namespace, then no javax-imports should be present in the generated files

**Current status (before this PR)**:
Generating Spring-sources with the new default validation-mode 'strict' creates java-files 'NotUndefined.java' and 'NotUndefinedValidator.java' with 'javax'-imports independent of the 'jakarta'-flag. This leads to a compile-time error, as these javax-imports cannot be found.

**Updated behavior**:
Dependant on the 'jakarta'-setting on the generator either 'javax'- or 'jakarta'-imports are generated