### PR TITLE
fix php enum allowable values delimiter generation

### DIFF
--- a/src/main/resources/handlebars/php/model_enum.mustache
+++ b/src/main/resources/handlebars/php/model_enum.mustache
@@ -17,7 +17,7 @@ class {{classname}}
         return [
             {{#allowableValues}}
             {{#enumVars}}
-            self::{{{name}}}{{#hasMore}},{{/hasMore}}
+            self::{{{name}}}{{^@last}},{{/@last}}
             {{/enumVars}}
             {{/allowableValues}}
         ];

--- a/src/main/resources/handlebars/php/model_generic.mustache
+++ b/src/main/resources/handlebars/php/model_generic.mustache
@@ -148,7 +148,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         return [
             {{#allowableValues}}
             {{#enumVars}}
-            self::{{enumName}}_{{{name}}}{{#hasMore}},{{/hasMore}}
+            self::{{enumName}}_{{{name}}}{{^@last}},{{/@last}}
             {{/enumVars}}
             {{/allowableValues}}
         ];


### PR DESCRIPTION
Use last instead of hasMore in php model templates for allowableValues data arrays to fix missing delimiter

This fixes 
- https://github.com/swagger-api/swagger-codegen-generators/issues/1164 
- https://github.com/swagger-api/swagger-codegen/issues/12411