### PR TITLE
Golang template: replace package `io/ioutil` with `io`

### DIFF
--- a/src/main/resources/handlebars/go/api.mustache
+++ b/src/main/resources/handlebars/go/api.mustache
@@ -5,7 +5,7 @@ package {{packageName}}
 {{#operations}}
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -178,7 +178,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}
 	}
 {{/required}}
 	if localVarFile != nil {
-		fbs, _ := ioutil.ReadAll(localVarFile)
+		fbs, _ := io.ReadAll(localVarFile)
 		localVarFileBytes = fbs
 		localVarFileName = localVarFile.Name()
 		localVarFile.Close()
@@ -237,7 +237,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}
 		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHttpResponse, err
 	}
 
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarBody, err := io.ReadAll(localVarHttpResponse.Body)
 	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHttpResponse, err


### PR DESCRIPTION
Replace package `io/ioutil` with `io`. Package `io/ioutil` is deprecated as of Go 1.16, the same functionality is provided by package `io`