### PR TITLE
[Java] [Feign] Add support for Feign 13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.swagger.codegen.v3</groupId>
     <artifactId>swagger-codegen-generators</artifactId>
-    <version>1.0.56</version>
+    <version>1.0.57-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <build>

--- a/src/main/resources/handlebars/Java/libraries/feign/auth/OAuth.mustache
+++ b/src/main/resources/handlebars/Java/libraries/feign/auth/OAuth.mustache
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 {{/java8}}
+import java.util.Date;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -99,7 +100,7 @@ public class OAuth implements RequestInterceptor {
         try {
             accessTokenResponse = oauthClient.accessToken(tokenRequestBuilder.buildBodyMessage());
         } catch (Exception e) {
-            throw new RetryableException(400, e.getMessage(), template.request().httpMethod(), e, null, template.request());
+            throw new RetryableException(400, e.getMessage(), template.request().httpMethod(), e, (Date) null, template.request());
         }
         if (accessTokenResponse != null && accessTokenResponse.getAccessToken() != null) {
             setAccessToken(accessTokenResponse.getAccessToken(), accessTokenResponse.getExpiresIn());

--- a/src/main/resources/handlebars/Java/libraries/feign/build.gradle.java11.mustache
+++ b/src/main/resources/handlebars/Java/libraries/feign/build.gradle.java11.mustache
@@ -16,7 +16,7 @@ ext {
     {{#threetenbp}}
     threepane_version = "2.6.4"
     {{/threetenbp}}
-    feign_version = "11.6"
+    feign_version = "13.5"
     feign_form_version = "3.8.0"
     junit_version = "4.13.1"
     oltu_version = "1.0.2"

--- a/src/main/resources/handlebars/Java/libraries/feign/pom.mustache
+++ b/src/main/resources/handlebars/Java/libraries/feign/pom.mustache
@@ -312,7 +312,7 @@
     {{^useOas2}}
     <swagger-core-version>2.0.0</swagger-core-version>
     {{/useOas2}}
-    <feign-version>11.6</feign-version>
+    <feign-version>13.5</feign-version>
     <feign-form-version>3.8.0</feign-form-version>
     <jackson-version>2.15.2</jackson-version>
     {{#threetenbp}}


### PR DESCRIPTION
As pointed out in the issue https://github.com/swagger-api/swagger-codegen/issues/12524, compilation fails for generated classes when Feign 13 and above are used.

The reason is version 13 adds an overload to the RetryableException constructor with the type Long instead of Date, and the value is passed as null causing the compiler to fail to resolve the constructor.

This PR applies https://github.com/swagger-api/swagger-codegen/pull/12525 for version 3.0