### PR TITLE
Fix adding/removing interceptors to OkHttpClient in OkHttp3

### DIFF
--- a/src/main/resources/handlebars/Java/libraries/okhttp4-gson/ApiClient.mustache
+++ b/src/main/resources/handlebars/Java/libraries/okhttp4-gson/ApiClient.mustache
@@ -80,7 +80,7 @@ public class ApiClient {
 
         {{#useGzipFeature}}
         // Enable gzip request compression
-        httpClient.interceptors().add(new GzipRequestInterceptor());
+        setHttpClient(getHttpClient.newBuilder().interceptors().add(new GzipRequestInterceptor()).build());
         {{/useGzipFeature}}
 
         json = new JSON();
@@ -338,9 +338,9 @@ public class ApiClient {
             if (debugging) {
                 loggingInterceptor = new HttpLoggingInterceptor();
                 loggingInterceptor.setLevel(Level.BODY);
-                httpClient.interceptors().add(loggingInterceptor);
+                setHttpClient(getHttpClient.newBuilder().interceptors().add(logginInterceptor).build());
             } else {
-                httpClient.interceptors().remove(loggingInterceptor);
+                setHttpClient(getHttpClient.newBuilder().interceptors().remove(logginInterceptor).build());
                 loggingInterceptor = null;
             }
         }

--- a/src/main/resources/handlebars/Java/libraries/okhttp4-gson/api.mustache
+++ b/src/main/resources/handlebars/Java/libraries/okhttp4-gson/api.mustache
@@ -114,7 +114,7 @@ public class {{classname}} {
         {{localVariablePrefix}}localVarHeaderParams.put("Content-Type", {{localVariablePrefix}}localVarContentType);
 
         if(progressListener != null) {
-            {{localVariablePrefix}}apiClient.getHttpClient().networkInterceptors().add(new okhttp3.Interceptor() {
+            okhttp3.Interceptor interceptor = new okhttp3.Interceptor() {
                 @Override
                 public okhttp3.Response intercept(okhttp3.Interceptor.Chain chain) throws IOException {
                     okhttp3.Response originalResponse = chain.proceed(chain.request());
@@ -122,7 +122,9 @@ public class {{classname}} {
                     .body(new ProgressResponseBody(originalResponse.body(), progressListener))
                     .build();
                 }
-            });
+            };
+            okhttp3.OkHttpClient newClient = {{localVariablePrefix}}apiClient.getHttpClient().newBuilder().addNetworkInterceptor(interceptor).build();
+            {{localVariablePrefix}}apiClient.setHttpClient(newClient);
         }
 
         String[] {{localVariablePrefix}}localVarAuthNames = new String[] { {{#authMethods}}"{{name}}"{{#hasMore}}, {{/hasMore}}{{/authMethods}} };


### PR DESCRIPTION
This PR addresses issue #1206 and fixes the same issue occuring at 2 other locations.

Starting from OkHttp3, interceptors cannot be added/removed directly onto a HttpClient object anymore, rather a Builder object should be used.