### PR TITLE
[Python] fixed docstring to comply with PEP 287

### DIFF
--- a/src/main/resources/handlebars/python/api.mustache
+++ b/src/main/resources/handlebars/python/api.mustache
@@ -43,11 +43,11 @@ class {{classname}}(object):
 {{/sortParamsByRequiredFlag}}
         >>> result = thread.get()
 
-        :param async_req bool
+        :param bool async_req:
 {{#parameters}}
         :param {{dataType}} {{paramName}}:{{#description}} {{{description}}}{{/description}}{{#required}} (required){{/required}}{{#optional}}(optional){{/optional}}
 {{/parameters}}
-        :return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}None{{/returnType}}
+        :return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}None{{/returnType}}.
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -74,11 +74,11 @@ class {{classname}}(object):
 {{/sortParamsByRequiredFlag}}
         >>> result = thread.get()
 
-        :param async_req bool
+        :param bool async_req:
 {{#parameters}}
         :param {{dataType}} {{paramName}}:{{#description}} {{{description}}}{{/description}}{{#required}} (required){{/required}}{{#optional}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/optional}}
 {{/parameters}}
-        :return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}None{{/returnType}}
+        :return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}None{{/returnType}}.
                  If the method is called asynchronously,
                  returns the request thread.
         """

--- a/src/main/resources/handlebars/python/api_client.mustache
+++ b/src/main/resources/handlebars/python/api_client.mustache
@@ -294,13 +294,13 @@ class ApiClient(object):
         :param header_params: Header parameters to be
             placed in the request header.
         :param body: Request body.
-        :param post_params dict: Request post form parameters,
+        :param dict post_params: Request post form parameters,
             for `application/x-www-form-urlencoded`, `multipart/form-data`.
-        :param auth_settings list: Auth Settings names for the request.
+        :param list auth_settings: Auth Settings names for the request.
         :param response: Response data type.
-        :param files dict: key -> filename, value -> filepath,
+        :param dict files: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param async_req bool: execute request asynchronously
+        :param bool async_req: execute request asynchronously
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param collection_formats: dict of collection formats for path, query,


### PR DESCRIPTION
# [Python] fixed docstring to comply with PEP 287
[Python] The python template predominantly uses [PEP 287 - reStructuredText (reST) format](https://peps.python.org/pep-0287/) for function documentation; however certain functions docstrings are in syntactic and or grammatical violation of the correct convention. This pull should correct those errors.

Useful links:
- https://peps.python.org/pep-0287/
- https://www.sphinx-doc.org/en/master/usage/domains/python.html#info-field-lists