### PR TITLE
Fix 1163 / do not import circular model references causing compilation errors

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/typescript/TypeScriptAxiosClientCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/typescript/TypeScriptAxiosClientCodegen.java
@@ -15,9 +15,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TreeSet;
+import java.util.stream.Collectors;
 
-import static io.swagger.codegen.v3.CodegenConstants.IS_CONTAINER_EXT_NAME;
 import static io.swagger.codegen.v3.generators.handlebars.ExtensionHelper.getBooleanValue;
 
 public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodegen {
@@ -190,8 +189,10 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
             // Deduce the model file name in kebab case
             cm.classFilename = cm.classname.replaceAll("([a-z0-9])([A-Z])", "$1-$2").toLowerCase(Locale.ROOT);
 
-            //processed enum names
-            cm.imports = new TreeSet<String>(cm.imports);
+            // Collect imports (don't add self referencing imports to the current model)
+            cm.imports = cm.imports.stream().filter(importClass -> !importClass.equals(cm.classname)).collect(Collectors.toSet());
+            
+            // process enum names
             // name enum with model name, e.g. StatusEnum => PetStatusEnum
             for (CodegenProperty var : cm.vars) {
                 if (getBooleanValue(var, CodegenConstants.IS_ENUM_EXT_NAME)) {


### PR DESCRIPTION
Address https://github.com/swagger-api/swagger-codegen-generators/issues/1163

Apply fix to address the same problem as https://github.com/swagger-api/swagger-codegen/issues/6201 in the axios code generator / template