### PR TITLE
Update interface.mustache to use discriminator object name instead default value 'type' for JsonTypeInfo

### DIFF
--- a/src/main/resources/handlebars/JavaSpring/interface.mustache
+++ b/src/main/resources/handlebars/JavaSpring/interface.mustache
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.PROPERTY,
-  property = "type")
+  property = "{{discriminator.propertyName}}")
 @JsonSubTypes({
   {{#subTypes}}
   @JsonSubTypes.Type(value = {{classname}}.class, name = "{{classname}}"){{^@last}},{{/@last}}


### PR DESCRIPTION
This change will enable Code Generator to generate Interfaces with Jackson JsonTypeInfo corresponding to the discriminator object name defined for oneOf type variable in Swagger, instead of having default value 'type'.