### PR TITLE
php/api.mustache: Fix missing body decoding before deserialization 

### DIFF
--- a/src/main/resources/handlebars/php/api.mustache
+++ b/src/main/resources/handlebars/php/api.mustache
@@ -182,8 +182,13 @@ use {{invokerPackage}}\ObjectSerializer;
         {{#responses}}
             {{#dataType}}
                 {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
+                    $content = $e->getResponseBody();
+                    if ('{{dataType}}' !== 'string' && '{{dataType}}' !== '\SplFileObject') {
+                        $content = json_decode($content);
+                    }
+
                     $data = ObjectSerializer::deserialize(
-                        $e->getResponseBody(),
+                        $content,
                         '{{dataType}}',
                         $e->getResponseHeaders()
                     );


### PR DESCRIPTION
Fixes an issue where the response body was not decoded before attempting to deserialize it into a model when an exception (non-2xx HTTP response) occurs.

Previously, the raw response body stream was passed directly to the deserializer inside the `ApiException` handling block, which caused deserialization to fail for structured response types (e.g. JSON).

This patch ensures that the body content is read and decoded (JSON-decoded if applicable) before passing it to `ObjectSerializer::deserialize()`, mirroring the successful response handling logic.