### PR TITLE
typescript-fetch: Make configuration nullable

### DIFF
--- a/src/main/resources/handlebars/typescript-fetch/api.mustache
+++ b/src/main/resources/handlebars/typescript-fetch/api.mustache
@@ -44,7 +44,7 @@ export interface FetchArgs {
  * @class BaseAPI
  */
 export class BaseAPI {
-    protected configuration: Configuration;
+    protected configuration?: Configuration;
 
     constructor(configuration?: Configuration, protected basePath: string = BASE_PATH, protected fetch: FetchAPI = isomorphicFetch) {
         if (configuration) {


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-codegen/issues/11870
Same as https://github.com/swagger-api/swagger-codegen/pull/12091/files for branch 3.0.0

This change for the typescript-fetch format allows to compile with strict mode enabled