### PR TITLE
issue-9509 adding escaping support to patterns added with ref properties

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -3185,7 +3185,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
                 if (this.openAPI == null) {
                     LOGGER.warn("open api utility object was not properly set.");
                 } else {
-                    OpenAPIUtil.addPropertiesFromRef(this.openAPI, propertySchema, codegenProperty);
+                    OpenAPIUtil.addPropertiesFromRef(this.openAPI, propertySchema, codegenProperty, this::toRegularExpression);
                 }
             }
 

--- a/src/main/java/io/swagger/codegen/v3/generators/util/OpenAPIUtil.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/util/OpenAPIUtil.java
@@ -4,6 +4,7 @@ package io.swagger.codegen.v3.generators.util;
 import io.swagger.codegen.v3.CodegenProperty;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
+import java.util.function.*;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
@@ -13,7 +14,7 @@ import static io.swagger.codegen.v3.CodegenConstants.HAS_VALIDATION_EXT_NAME;
 
 public class OpenAPIUtil {
 
-    public static void addPropertiesFromRef(OpenAPI openAPI, Schema refSchema, CodegenProperty codegenProperty) {
+    public static void addPropertiesFromRef(OpenAPI openAPI, Schema refSchema, CodegenProperty codegenProperty, UnaryOperator<String> toRegularExpression) {
         final Map<String, Schema> allSchemas = openAPI.getComponents().getSchemas();
         if (allSchemas == null || allSchemas.isEmpty()) {
             return;
@@ -23,7 +24,7 @@ public class OpenAPIUtil {
             return;
         }
         if (StringUtils.isBlank(codegenProperty.pattern)) {
-            codegenProperty.pattern = schema.getPattern();
+            codegenProperty.pattern = toRegularExpression.apply(schema.getPattern());
         }
         codegenProperty.minLength = schema.getMinLength();
         codegenProperty.maxLength = schema.getMaxLength();

--- a/src/test/java/io/swagger/codegen/v3/generators/DefaultCodegenConfigTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/DefaultCodegenConfigTest.java
@@ -86,8 +86,8 @@ public class DefaultCodegenConfigTest {
     @Test
     public void testNumberSchemaMinMax() {
         Schema schema = new NumberSchema()
-            .minimum(BigDecimal.valueOf(50))
-            .maximum(BigDecimal.valueOf(1000));
+                .minimum(BigDecimal.valueOf(50))
+                .maximum(BigDecimal.valueOf(1000));
 
         final DefaultCodegenConfig codegen = new P_DefaultCodegenConfig();
         CodegenProperty codegenProperty = codegen.fromProperty("test", schema);
@@ -133,13 +133,13 @@ public class DefaultCodegenConfigTest {
         final DefaultCodegenConfig codegen = new P_DefaultCodegenConfig();
 
         ArraySchema paramSchema = new ArraySchema()
-            .items(new IntegerSchema());
+                .items(new IntegerSchema());
         Parameter param = new Parameter()
-            .in("query")
-            .name("testParameter")
-            .schema(paramSchema)
-            .style(style)
-            .explode(explode);
+                .in("query")
+                .name("testParameter")
+                .schema(paramSchema)
+                .style(style)
+                .explode(explode);
 
         CodegenParameter codegenParameter = codegen.fromParameter(param, new HashSet<>());
 
@@ -150,21 +150,21 @@ public class DefaultCodegenConfigTest {
     public Object[][] provideData_testGetCollectionFormat() {
         // See: https://swagger.io/docs/specification/serialization/#query
         return new Object[][] {
-            {null, null, "multi"},
-            {Parameter.StyleEnum.FORM, null, "multi"},
-            {null, Boolean.TRUE, "multi"},
-            {Parameter.StyleEnum.FORM, Boolean.TRUE, "multi"},
+            { null,                                 null,           "multi" },
+            { Parameter.StyleEnum.FORM,             null,           "multi" },
+            { null,                                 Boolean.TRUE,   "multi" },
+            { Parameter.StyleEnum.FORM,             Boolean.TRUE,   "multi" },
 
-            {null, Boolean.FALSE, "csv"},
-            {Parameter.StyleEnum.FORM, Boolean.FALSE, "csv"},
+            { null,                                 Boolean.FALSE,  "csv" },
+            { Parameter.StyleEnum.FORM,             Boolean.FALSE,  "csv" },
 
-            {Parameter.StyleEnum.SPACEDELIMITED, Boolean.TRUE, "multi"},
-            {Parameter.StyleEnum.SPACEDELIMITED, Boolean.FALSE, "space"},
-            {Parameter.StyleEnum.SPACEDELIMITED, null, "multi"},
+            { Parameter.StyleEnum.SPACEDELIMITED,   Boolean.TRUE,   "multi" },
+            { Parameter.StyleEnum.SPACEDELIMITED,   Boolean.FALSE,  "space" },
+            { Parameter.StyleEnum.SPACEDELIMITED,   null,           "multi" },
 
-            {Parameter.StyleEnum.PIPEDELIMITED, Boolean.TRUE, "multi"},
-            {Parameter.StyleEnum.PIPEDELIMITED, Boolean.FALSE, "pipe"},
-            {Parameter.StyleEnum.PIPEDELIMITED, null, "multi"},
+            { Parameter.StyleEnum.PIPEDELIMITED,    Boolean.TRUE,   "multi" },
+            { Parameter.StyleEnum.PIPEDELIMITED,    Boolean.FALSE,  "pipe" },
+            { Parameter.StyleEnum.PIPEDELIMITED,    null,           "multi" },
         };
     }
 
@@ -352,10 +352,9 @@ public class DefaultCodegenConfigTest {
         schema.setPattern(StringEscapeUtils.unescapeJava(SSN_ESCAPED_PATTERN));
         return schema;
     }
-
     @DataProvider(name = "testCommonPrefixProvider")
     public Object[][] provideData_testCommonPrefix() {
-        return new Object[][] {
+        return new Object[][]{
             {Collections.singletonList("FOO_BAR"), ""},
             {Arrays.asList("FOO_BAR", "FOO_BAZ"), "FOO_"},
             {Arrays.asList("FOO_BAR", "FOO_BAZ", "TEST"), ""},
@@ -363,7 +362,7 @@ public class DefaultCodegenConfigTest {
         };
     }
 
-    private static class P_DefaultCodegenConfig extends DefaultCodegenConfig {
+    private static class P_DefaultCodegenConfig extends DefaultCodegenConfig{
         @Override
         public String getArgumentsLocation() {
             return null;


### PR DESCRIPTION
as was already stated in https://github.com/swagger-api/swagger-codegen/issues/9509 

> Regex pattern like this '^\d{1,13}.\d{1,5}$' are not escape property and the generated java code does not compile.

tho, it was fixed in v2 of swagger-codegen
https://github.com/swagger-api/swagger-codegen-generators/pull/1100
https://github.com/swagger-api/swagger-codegen/pull/12038

it remains broken for swagger v3,

> any chance to get this work resumed and merged, specially into v3? Thanks.

In this change I'm addressing `pattern` escaping for properties constructed from references.