### PR TITLE
fix issue where lists of inner enums don't correctly generate

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -1948,7 +1948,7 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
 
         if (baseItem != null) {
             // set both datatype and datetypeWithEnum as only the inner type is enum
-            property.datatypeWithEnum = property.datatypeWithEnum.replace(", " + baseItem.baseType, ", " + toEnumName(baseItem));
+            property.datatypeWithEnum = property.datatypeWithEnum.replace(baseItem.baseType + ">", toEnumName(baseItem) + ">");
 
             // naming the enum with respect to the language enum naming convention
             // e.g. remove [], {} from array/map of enum

--- a/src/test/java/io/swagger/codegen/v3/generators/java/JavaClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/JavaClientCodegenTest.java
@@ -343,4 +343,20 @@ public class JavaClientCodegenTest extends AbstractCodegenTest {
 
         Assert.assertTrue(hasComposedModel);
     }
+
+    @Test
+    public void testMapOfInnerEnum() {
+        final OpenAPI openAPI = getOpenAPI("3_0_0/map_of_inner_enum.yaml");
+        final JavaClientCodegen config = new JavaClientCodegen();
+        final CodegenWrapper codegenWrapper = processSchemas(config, openAPI);
+
+        final Map<String, CodegenModel> codegenModels = codegenWrapper.getAllModels();
+
+        final CodegenModel employeeWithMapOfEnum = codegenModels.get("EmployeeWithMapOfEnum");
+        Assert.assertEquals(employeeWithMapOfEnum.vars.get(0).datatypeWithEnum, "Map<String, InnerEnum>");
+
+        final CodegenModel employeeWithMultiMapOfEnum = codegenModels.get("EmployeeWithMultiMapOfEnum");
+        Assert.assertEquals(employeeWithMultiMapOfEnum.vars.get(0).datatypeWithEnum, "Map<String, List<InnerEnum>>");
+
+    }
 }

--- a/src/test/resources/3_0_0/map_of_inner_enum.yaml
+++ b/src/test/resources/3_0_0/map_of_inner_enum.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: OpenAPI Test API
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /status:
+    get:
+      responses:
+        '200':
+          description: desc
+components:
+  schemas:
+    EmployeeWithMapOfEnum:
+      type: object
+      properties:
+        projectRole:
+          type: object
+          additionalProperties:
+            type: string
+            enum:
+              - DEVELOPER
+              - TESTER
+              - OWNER
+    EmployeeWithMultiMapOfEnum:
+      type: object
+      properties:
+        projectRoles:
+          type: object
+          additionalProperties:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+              enum:
+                - DEVELOPER
+                - TESTER
+                - OWNER


### PR DESCRIPTION
# Pull Request

## Description

Fixes: #1353 

Example error from before:

```
incompatible types: java.util.Set<Employee.InnerEnum> cannot be converted to java.util.Set<java.lang.String>
```

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## How to Test

See example within #1353 or unit test added.

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->