### PR TITLE
Fix NullPointerException when generating java code Descriminator Object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>swagger-codegen-generators</name>
     <description>swagger-codegen-generators</description>
     <url>https://github.com/swagger-api/swagger-codegen-generators</url>
-    <version>1.0.58</version>
+    <version>1.0.59</version>
     <packaging>jar</packaging>
     <scm>
         <connection>scm:git:git@github.com:swagger-api/swagger-codegen-generators.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>swagger-codegen-generators</name>
     <description>swagger-codegen-generators</description>
     <url>https://github.com/swagger-api/swagger-codegen-generators</url>
-    <version>1.0.59</version>
+    <version>1.0.58</version>
     <packaging>jar</packaging>
     <scm>
         <connection>scm:git:git@github.com:swagger-api/swagger-codegen-generators.git</connection>

--- a/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/DefaultCodegenConfig.java
@@ -1399,16 +1399,20 @@ public abstract class DefaultCodegenConfig implements CodegenConfig {
 
                     if (composed.getOneOf()!=null) {
                         composed.getOneOf().forEach( s -> {
-                            codegenModel.discriminator.getMapping().keySet().stream().filter( key -> codegenModel.discriminator.getMapping().get(key).equals(s.get$ref()))
-                                .forEach(key -> {
-                                    String mappingValue = codegenModel.discriminator.getMapping().get(key);
-                                    if (classnameKeys.containsKey(codegenModel.classname)) {
-                                        throw new IllegalArgumentException("Duplicate shema name in discriminator mapping");
-                                    }
-                                    classnameKeys.put(toModelName(mappingValue.replace("#/components/schemas/", "")),key);
-                                });
+                            if(codegenModel.discriminator.getMapping() != null){
+                                codegenModel.discriminator.getMapping().keySet().stream().filter( key -> codegenModel.discriminator.getMapping().get(key).equals(s.get$ref()))
+                                    .forEach(key -> {
+                                        String mappingValue = codegenModel.discriminator.getMapping().get(key);
+                                        if (classnameKeys.containsKey(codegenModel.classname)) {
+                                            throw new IllegalArgumentException("Duplicate shema name in discriminator mapping");
+                                        }
+                                        classnameKeys.put(toModelName(mappingValue.replace("#/components/schemas/", "")),key);
+                                    });
+                                codegenModel.discriminator.getMapping().putAll(classnameKeys);
+
+                            }
+
                         });
-                        codegenModel.discriminator.getMapping().putAll(classnameKeys);
                     }
                 }
 


### PR DESCRIPTION
# Pull Request


## Description

Fix NullPointerException


Fixes: https://github.com/swagger-api/swagger-codegen-generators/issues/1379

## Type of Change


- [ x] 🐛 Bug fix


## Checklist

- [ x] I have added/updated tests as needed
- [x ] I have added/updated documentation where applicable
- [ x] The PR title is descriptive
- [ x] The code builds and passes tests locally
- [ x] I have linked related issues (if any)


## Screenshots / Additional Context

[ERROR]  java.lang.RuntimeException: Could not process model 'ModelDto'.Please make sure that your schema is correct! at io.swagger.codegen.v3.DefaultGenerator.generateModels (DefaultGenerator.java:391) at io.swagger.codegen.v3.DefaultGenerator.generate (DefaultGenerator.java:852) at io.swagger.codegen.v3.maven.plugin.CodeGenMojo.execute_ (CodeGenMojo.java:567) at io.swagger.codegen.v3.maven.plugin.CodeGenMojo.execute (CodeGenMojo.java:326) at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126) at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328) at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316) at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212) at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174) at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75) at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162) at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39) at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159) at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105) at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73) at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53) at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118) at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261) at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173) at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101) at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906) at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283) at org.apache.maven.cli.MavenCli.main (MavenCli.java:206) at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method) at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77) at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43) at java.lang.reflect.Method.invoke (Method.java:568) at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255) at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201) at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361) at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314) Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Map.keySet()" because the return value of "io.swagger.v3.oas.models.media.Discriminator.getMapping()" is null at io.swagger.codegen.v3.generators.DefaultCodegenConfig.lambda$fromModel$2 (DefaultCodegenConfig.java:1402) at java.util.ArrayList.forEach (ArrayList.java:1511) at io.swagger.codegen.v3.generators.DefaultCodegenConfig.fromModel (DefaultCodegenConfig.java:1401) at io.swagger.codegen.v3.generators.java.AbstractJavaCodegen.fromModel (AbstractJavaCodegen.java:983) at io.swagger.codegen.v3.DefaultGenerator.processModels (DefaultGenerator.java:1128) at io.swagger.codegen.v3.DefaultGenerator.generateModels (DefaultGenerator.java:380) at io.swagger.codegen.v3.DefaultGenerator.generate (DefaultGenerator.java:852) at io.swagger.codegen.v3.maven.plugin.CodeGenMojo.execute_ (CodeGenMojo.java:567) at io.swagger.codegen.v3.maven.plugin.CodeGenMojo.execute (CodeGenMojo.java:326) at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126) at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328) at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316) at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212) at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174) at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75) at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162) at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39) at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159) at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105) at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73) at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53) at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118) at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261) at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173) at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101) at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906) at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283) at org.apache.maven.cli.MavenCli.main (MavenCli.java:206) at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method) at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77) at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43) at java.lang.reflect.Method.invoke (Method.java:568) at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255) at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201) at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361) at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314) [INFO] ------------------------------------------------------------------------ [INFO] BUILD FAILURE [INFO] ---------------------------------