### PR TITLE
[Python] Fix allOf inheritance by using **kwargs throughout inheritance chain

### DIFF
--- a/src/main/resources/handlebars/python/model.mustache
+++ b/src/main/resources/handlebars/python/model.mustache
@@ -67,7 +67,29 @@ class {{classname}}({{#parent}}{{parent}}{{/parent}}{{^parent}}object{{/parent}}
     }
 {{/discriminator}}
 
-    def __init__(self{{#vars}}, {{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}{{/vars}}{{#parent}}, *args, **kwargs{{/parent}}):  # noqa: E501
+{{#parent}}
+    def __init__(self, **kwargs):  # noqa: E501
+        """{{classname}} - a model defined in Swagger"""  # noqa: E501
+{{#vars}}{{#@first}}
+{{/@first}}
+        self._{{name}} = None
+{{/vars}}
+        self.discriminator = {{#discriminator}}'{{discriminator.propertyName}}'{{/discriminator}}{{^discriminator}}None{{/discriminator}}
+{{#vars}}{{#@first}}
+{{/@first}}
+        {{name}} = kwargs.get('{{name}}'{{#defaultValue}}, {{{defaultValue}}}{{/defaultValue}})
+{{#required}}
+        self.{{name}} = {{name}}
+{{/required}}
+{{^required}}
+        if {{name}} is not None:
+            self.{{name}} = {{name}}
+{{/required}}
+{{/vars}}
+        {{parent}}.__init__(self, **kwargs)
+{{/parent}}
+{{^parent}}
+    def __init__(self{{#vars}}, {{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}{{/vars}}, **kwargs):  # noqa: E501
         """{{classname}} - a model defined in Swagger"""  # noqa: E501
 {{#vars}}{{#@first}}
 {{/@first}}
@@ -84,8 +106,6 @@ class {{classname}}({{#parent}}{{parent}}{{/parent}}{{^parent}}object{{/parent}}
             self.{{name}} = {{name}}
 {{/required}}
 {{/vars}}
-{{#parent}}
-        {{parent}}.__init__(self, *args, **kwargs)
 {{/parent}}
 
 {{#vars}}


### PR DESCRIPTION
## Summary

When a child model extends a parent via `allOf`, the generated `__init__` method was consuming parameters from kwargs, preventing them from reaching parent classes. This caused deserialization failures with errors like:

- `ValueError: Invalid value for 'name' (None), must not be 'None'`
- `TypeError: Parent.__init__() got an unexpected keyword argument 'child_field'`

## The Problem

Consider this OpenAPI spec with inheritance:

```yaml
components:
  schemas:
    Parent:
      type: object
      required: [name, type]
      properties:
        name:
          type: string
        type:
          type: string
          enum: [typeA, typeB]
    
    Child:
      allOf:
        - $ref: '#/components/schemas/Parent'
        - type: object
          properties:
            child_field:
              type: string
```

The **old generated code** had two problems:

```python
class Child(Parent):
    def __init__(self, name=None, type=None, child_field=None, *args, **kwargs):
        self._name = None
        self._type = None
        self._child_field = None
        self.name = name          # consumed from kwargs
        self.type = type          # consumed from kwargs  
        self.child_field = child_field
        Parent.__init__(self, *args, **kwargs)  # BUG: name, type NOT in kwargs anymore!

class Parent:
    def __init__(self, name=None, type=None):  # No **kwargs - rejects unknown params!
        self.name = name  # Gets None because Child consumed it
        self.type = type  # Gets None because Child consumed it
```

**Problem 1**: Python extracts named parameters from `**kwargs` into local variables, so when `Parent.__init__` is called, those parameters are no longer in kwargs.

**Problem 2**: Root classes didn't accept `**kwargs`, so if a child class has fields the parent doesn't know about, it fails with "unexpected keyword argument".

## The Fix

**For child classes (with parent)**: Use `**kwargs` for all parameters and extract with `kwargs.get()`:

```python
class Child(Parent):
    def __init__(self, **kwargs):
        self._name = None
        self._type = None
        self._child_field = None
        name = kwargs.get('name')
        type = kwargs.get('type')
        child_field = kwargs.get('child_field')
        self.name = name
        self.type = type
        self.child_field = child_field
        Parent.__init__(self, **kwargs)  # Full kwargs passed through!
```

**For root classes (without parent)**: Add `**kwargs` to accept extra parameters:

```python
class Parent:
    def __init__(self, name=None, type=None, **kwargs):  # Accepts extra kwargs
        self.name = name
        self.type = type
```

This ensures the full kwargs dict flows through the entire inheritance chain, and each class extracts what it needs without breaking the chain.

## Test Plan

- [x] Generated a Python client with multi-level `allOf` inheritance
- [x] Verified child class instances correctly populate parent class attributes
- [x] Verified parent classes correctly ignore unknown child-specific fields
- [x] Tested deserialization of API responses with inherited models
- [x] In my project: all unit tests pass
- [x] In my project: all integration tests pass (against production API)

## Diagnosis Notes

This bug manifests as errors like:
- `ValueError: Invalid value for 'property_name' (None), must not be 'None'`
- `ValueError: Invalid value for 'property_name' (None), must be one of [...]`
- Parent class validation failures during deserialization of child objects

## Repro Notes

- My OpenAPI schema is at [here](https://github.com/ericfitz/tmi/blob/main/docs/reference/apis/tmi-openapi.json)
- My OpenAPI client generation code is [here](https://github.com/ericfitz/tmi-clients)
- I generated my client with swagger-codegen 3.0.75
- Tested with Python 3.14.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
🧍🏻Manually reviewed and edited by a real human, not just AI slop