### PR TITLE
Update java requirement in readme to Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ More details about these and more differences are referenced at [https://github.
 ### Prerequisites
 You need the following installed and available in your $PATH:
 
-* Java 8 (http://java.oracle.com)
+* Java 11+ (http://java.oracle.com)
 * Apache maven 3.0.4 or greater (http://maven.apache.org/)
 
 ## How to Contribute.


### PR DESCRIPTION
it is still compiled with binary compatibility of 8 but Java 11 is required to do the build, otherwise there is this error:

```
[ERROR] Failed to execute goal
org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile(default-compile)
on project swagger-codegen-generators: Fatal error compiling: invalid
flag: --release
```

# Pull Request

Thank you for contributing to **swagger-codegen-generators**!

Please fill out the following checklist to help us review your PR efficiently.

---

## Description

<!--
Clearly describe what your PR does.
- What feature or fix are you adding?
- Which templates or generators are affected?
- Is it related to a specific issue?
-->


Fixes: <!-- e.g. #123 (optional) -->

## Type of Change

<!-- Check all that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [x] 📝 Documentation
- [x] 🧹 Chore (build or tooling)

## Checklist

- [ ] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [ ] The code builds and passes tests locally
- [ ] I have linked related issues (if any)

## How to Test

<!--
Describe how reviewers can test your changes.
Include sample command lines or configurations if applicable.
-->

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->