### PR TITLE
fix(python): validate map values (not keys) for additionalProperties.enum

### DIFF
--- a/src/main/resources/handlebars/python/model.mustache
+++ b/src/main/resources/handlebars/python/model.mustache
@@ -129,10 +129,10 @@ class {{classname}}({{#parent}}{{parent}}{{/parent}}{{^parent}}object{{/parent}}
             )
 {{/isListContainer}}
 {{#isMapContainer}}
-        if not set({{{name}}}.keys()).issubset(set(allowed_values)):
+        if not set({{{name}}}.values()).issubset(set(allowed_values)):
             raise ValueError(
-                "Invalid keys in `{{{name}}}` [{0}], must be a subset of [{1}]"  # noqa: E501
-                .format(", ".join(map(str, set({{{name}}}.keys()) - set(allowed_values))),  # noqa: E501
+                "Invalid values in `{{{name}}}` [{0}], must be a subset of [{1}]"  # noqa: E501
+                .format(", ".join(map(str, set({{{name}}}.values()) - set(allowed_values))),  # noqa: E501
                         ", ".join(map(str, allowed_values)))
             )
 {{/isMapContainer}}

--- a/src/main/resources/handlebars/pythonFlaskConnexion/model.mustache
+++ b/src/main/resources/handlebars/pythonFlaskConnexion/model.mustache
@@ -99,10 +99,10 @@ class {{classname}}(Model):
             )
 {{/isListContainer}}
 {{#isMapContainer}}
-        if not set({{{name}}}.keys()).issubset(set(allowed_values)):
+        if not set({{{name}}}.values()).issubset(set(allowed_values)):
             raise ValueError(
-                "Invalid keys in `{{{name}}}` [{0}], must be a subset of [{1}]"  # noqa: E501
-                .format(", ".join(map(str, set({{{name}}}.keys()) - set(allowed_values))),  # noqa: E501
+                "Invalid values in `{{{name}}}` [{0}], must be a subset of [{1}]"  # noqa: E501
+                .format(", ".join(map(str, set({{{name}}}.values()) - set(allowed_values))),  # noqa: E501
                         ", ".join(map(str, allowed_values)))
             )
 {{/isMapContainer}}

--- a/src/test/java/io/swagger/codegen/v3/generators/python/PythonMapEnumValidationTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/python/PythonMapEnumValidationTest.java
@@ -1,0 +1,60 @@
+package io.swagger.codegen.v3.generators.python;
+
+import io.swagger.codegen.v3.generators.GeneratorRunner;
+import io.swagger.codegen.v3.service.GenerationRequest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Regression test for the Python generator `Map&lt;String, Enum&gt;` setter validation.
+ *
+ * <p>The {@code model.mustache} template used to emit
+ * {@code set(x.keys()).issubset(allowed_values)} for properties declared as
+ * {@code type: object} with {@code additionalProperties.enum}. Per OpenAPI 3.0
+ * semantics, {@code additionalProperties} describes map values, so the enum
+ * constraint applies to the values, not the keys. The fix validates
+ * {@code set(x.values()).issubset(allowed_values)} and updates the error message
+ * from "Invalid keys in" to "Invalid values in".
+ */
+public class PythonMapEnumValidationTest {
+
+    @Test
+    public void mapOfEnumSetterValidatesValuesNotKeys() throws Exception {
+        final List<File> files = GeneratorRunner.runGenerator(
+            "python",
+            "3_0_0/map_of_inner_enum.yaml",
+            GenerationRequest.CodegenVersion.V3,
+            false,
+            true,
+            true,
+            null,
+            options -> {});
+
+        Assert.assertFalse(files.isEmpty());
+
+        final File modelFile = files.stream()
+            .filter(f -> f.getName().equals("employee_with_map_of_enum.py"))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("employee_with_map_of_enum.py was not generated"));
+
+        final String content = new String(Files.readAllBytes(Paths.get(modelFile.toURI())));
+
+        Assert.assertTrue(
+            content.contains("set(project_role.values()).issubset(set(allowed_values))"),
+            "Setter should validate map values (not keys) against the enum.\nGenerated:\n" + content);
+        Assert.assertTrue(
+            content.contains("Invalid values in `project_role`"),
+            "Setter error message should reference 'Invalid values in'.\nGenerated:\n" + content);
+        Assert.assertFalse(
+            content.contains("set(project_role.keys()).issubset(set(allowed_values))"),
+            "Setter must not validate map keys against the enum.\nGenerated:\n" + content);
+        Assert.assertFalse(
+            content.contains("Invalid keys in `project_role`"),
+            "Setter error message must not reference 'Invalid keys in'.\nGenerated:\n" + content);
+    }
+}


### PR DESCRIPTION
## Description

The `python` and `pythonFlaskConnexion` generator templates produced setter validation that compared map **keys** to the enum, while OpenAPI 3.0 `additionalProperties.enum` constrains map **values**. Any realistic payload with arbitrary string keys (parameter names, identifiers, tags, etc.) failed deserialization with a spurious `ValueError`.

This PR:

- Fixes the `{{#isMapContainer}}` branch inside `{{#isEnum}}` → `{{#isContainer}}` in `src/main/resources/handlebars/python/model.mustache` (lines 131-138) and `src/main/resources/handlebars/pythonFlaskConnexion/model.mustache` (lines 101-108) so setters validate `.values()` rather than `.keys()` and the error message reads `Invalid values in ...` rather than `Invalid keys in ...`.
- Adds a regression test, `PythonMapEnumValidationTest`, that uses the existing `3_0_0/map_of_inner_enum.yaml` fixture and `GeneratorRunner.runGenerator` to assert the generated Python model contains the corrected validation.

The fix is byte-minimal: six substitutions across the two templates.

### Before (broken)

```python
allowed_values = ["DEVELOPER", "TESTER", "OWNER"]
if not set(project_role.keys()).issubset(set(allowed_values)):
    raise ValueError(
        "Invalid keys in `project_role` [{0}], must be a subset of [{1}]"
        ...
    )
```

### After (correct)

```python
allowed_values = ["DEVELOPER", "TESTER", "OWNER"]
if not set(project_role.values()).issubset(set(allowed_values)):
    raise ValueError(
        "Invalid values in `project_role` [{0}], must be a subset of [{1}]"
        ...
    )
```

Fixes #1404

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (non-breaking change)
- [x] Tests
- [ ] Documentation
- [ ] Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally (see note below about TestNG runner)
- [x] I have linked related issues

## How to Test

1. Check out the branch and build: `./mvnw clean test-compile` — should succeed.
2. Reproduce the original bug (before the fix) by generating Python with `swagger-codegen-cli 3.0.77` from a spec containing a `Map<String, Enum>` property (for example, `3_0_0/map_of_inner_enum.yaml` in this repo). Inspect `employee_with_map_of_enum.py`; prior to this fix, the setter for `project_role` validates `.keys()` against the enum.
3. After applying this PR, regenerate from the same spec and verify the setter validates `.values()` and the error message reads `Invalid values in 'project_role'`.
4. Automated: `PythonMapEnumValidationTest.mapOfEnumSetterValidatesValuesNotKeys` exercises the end-to-end generation and asserts on the generated file contents.

### Note on test execution

The project uses TestNG for its tests (see the rest of `src/test/java/.../python/`, `.../java/`, etc.), and this PR follows that convention. The current `pom.xml` Surefire configuration has `<testNGArtifactName>none:none</testNGArtifactName>` at line 93, which excludes TestNG from default `mvn test` / `mvn verify` runs. As a result this and all other TestNG tests in the suite do not execute in the default CI pipeline today — this is a pre-existing, project-wide situation, not something introduced by this PR. The new test compiles cleanly and can be executed from an IDE (IntelliJ, Eclipse) or by temporarily overriding the Surefire config. Happy to align with whatever runner strategy maintainers prefer if you'd like the test refactored.

## Screenshots / Additional Context

Discovered while integrating an OpenAPI 3.0 spec from Apache NiFi (`ParameterGroupConfigurationEntity.parameterSensitivities`) into [nipyapi](https://github.com/Chaffelson/nipyapi), which generates its Python client with `swagger-codegen-cli 3.0.68`. The NiFi spec correctly places the enum on `additionalProperties` (per OAS 3.0 semantics), but the generated Python client rejected every response because of the `Invalid keys in \`parameter_sensitivities\`` check. The same bug exists through at least `v1.0.77`.

See issue #1404 for a minimal reproducer spec and additional context.
