### PR TITLE
[TS-fetch - v3] Add support for bearer token authentication

### DIFF
--- a/src/main/resources/handlebars/typescript-fetch/api.mustache
+++ b/src/main/resources/handlebars/typescript-fetch/api.mustache
@@ -144,7 +144,15 @@ export const {{classname}}FetchParamCreator = function (configuration?: Configur
                 localVarHeaderParameter["Authorization"] = "Bearer " + localVarAccessTokenValue;
             }
             {{/isOAuth}}
-
+            {{#isBearer}}
+	        // bearer token required
+	        if (configuration && configuration.accessToken) {
+				const localVarAccessTokenValue = typeof configuration.accessToken === 'function'
+					? configuration.accessToken("{{name}}")
+					: configuration.accessToken;
+                localVarHeaderParameter["Authorization"] = "Bearer " + localVarAccessTokenValue;
+            }
+	        {{/isBearer}}
     {{/authMethods}}
     {{#queryParams}}
             {{#isListContainer}}


### PR DESCRIPTION
Based on https://github.com/swagger-api/swagger-codegen/issues/9493

# Pull Request

Note :
This PR has the exact same purpose than [this one](https://github.com/swagger-api/swagger-codegen/pull/12750), but for the v3 version of swagger-codegen.

## Description

Based on how [PHP template deals with Bearer auth](https://github.com/swagger-api/swagger-codegen-generators/blob/da463b8ff4d4c25c7643606bedb01cb363412d76/src/main/resources/handlebars/php/api.mustache#L469), I did the same in the typescript-fetch mustache template.

The token should be passed to the accessToken configuration key (as in the php code). If a function is given, we call it without the scope argument (as authorized in the definition of accessToken).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [ ] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [ ] The code builds and passes tests locally
- [x] I have linked related issues (if any)

For the 2 unchecked points, see the [notes section](#notes)

## How to Test

Using [this authorization schema](https://swagger.io/docs/specification/v3_0/authentication/bearer-authentication/), then generate using the `-l typescript-fetch` flag, and see the `Bearer` authentification in the `Authorization` header being passed in the `FetchParamCreator` of the model.

## Notes

Maybe I should add some java tests to test this, but idk how to write/test java in such big project.
