### PR TITLE
Issue/12751 stale test folder path after specifying source folder

### DIFF
--- a/src/main/java/io/swagger/codegen/v3/generators/dotnet/AbstractCSharpCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/dotnet/AbstractCSharpCodegen.java
@@ -236,6 +236,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegenConfig {
         // {{sourceFolder}}
         if (additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)) {
             setSourceFolder((String) additionalProperties.get(CodegenConstants.SOURCE_FOLDER));
+            setTestFolder((String) additionalProperties.get(CodegenConstants.SOURCE_FOLDER));
         } else {
             additionalProperties.put(CodegenConstants.SOURCE_FOLDER, this.sourceFolder);
         }
@@ -917,6 +918,10 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegenConfig {
 
     public void setSourceFolder(String sourceFolder) {
         this.sourceFolder = sourceFolder;
+    }
+
+    public void setTestFolder(String testFolder) {
+        this.testFolder = testFolder;
     }
 
     public String getInterfacePrefix() {

--- a/src/main/java/io/swagger/codegen/v3/generators/dotnet/AbstractCSharpCodegen.java
+++ b/src/main/java/io/swagger/codegen/v3/generators/dotnet/AbstractCSharpCodegen.java
@@ -916,10 +916,17 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegenConfig {
         this.packageAuthors = packageAuthors;
     }
 
+    public String getSourceFolder() {
+        return this.sourceFolder;
+    }
+
     public void setSourceFolder(String sourceFolder) {
         this.sourceFolder = sourceFolder;
     }
 
+    public String getTestFolder() {
+        return this.testFolder;
+    }
     public void setTestFolder(String testFolder) {
         this.testFolder = testFolder;
     }

--- a/src/main/resources/handlebars/csharp-471/README.mustache
+++ b/src/main/resources/handlebars/csharp-471/README.mustache
@@ -40,7 +40,7 @@ NOTE: RestSharp versions greater than 105.1.0 have a bug which causes file uploa
 
 Run the following commands to generate the DLL
 ```
-cd src/{{packageName}}
+cd {{sourceFolder}}/{{packageName}}
 dotnet restore
 dotnet build
 ```

--- a/src/main/resources/handlebars/csharp-471/Solution.mustache
+++ b/src/main/resources/handlebars/csharp-471/Solution.mustache
@@ -2,9 +2,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio {{^netStandard}}2012{{/netStandard}}{{#netStandard}}14{{/netStandard}}
 VisualStudioVersion = {{^netStandard}}12.0.0.0{{/netStandard}}{{#netStandard}}14.0.25420.1{{/netStandard}}
 MinimumVisualStudioVersion = {{^netStandard}}10.0.0.1{{/netStandard}}{{#netStandard}}10.0.40219.1{{/netStandard}}
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{packageName}}", "src{{backslash}}{{packageName}}{{backslash}}{{packageName}}.csproj", "{{packageGuid}}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{packageName}}", "{{sourceFolder}}{{backslash}}{{packageName}}{{backslash}}{{packageName}}.csproj", "{{packageGuid}}"
 EndProject
-{{^excludeTests}}Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{testPackageName}}", "src{{backslash}}{{testPackageName}}{{backslash}}{{testPackageName}}.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
+{{^excludeTests}}Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{testPackageName}}", "{{sourceFolder}}{{backslash}}{{testPackageName}}{{backslash}}{{testPackageName}}.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
 {{/excludeTests}}Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/main/resources/handlebars/csharp-471/mono_nunit_test.mustache
+++ b/src/main/resources/handlebars/csharp-471/mono_nunit_test.mustache
@@ -7,16 +7,16 @@ wget -nc https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
 mozroots --import --sync
 
 echo "[INFO] remove bin/Debug/SwaggerClientTest.dll"
-rm src/{{{packageName}}}.Test/bin/Debug/{{{packageName}}}.Test.dll 2> /dev/null
+rm {{sourceFolder}}/{{{packageName}}}.Test/bin/Debug/{{{packageName}}}.Test.dll 2> /dev/null
 
 echo "[INFO] install NUnit runners via NuGet"
 wget -nc https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
 mozroots --import --sync
-mono nuget.exe install src/{{{packageName}}}.Test/packages.config -o packages
+mono nuget.exe install {{sourceFolder}}/{{{packageName}}}.Test/packages.config -o packages
 
 echo "[INFO] Install NUnit runners via NuGet"
 mono nuget.exe install NUnit.Runners -Version 2.6.4 -OutputDirectory packages 
 
 echo "[INFO] Build the solution and run the unit test"
 xbuild {{{packageName}}}.sln && \
-    mono ./packages/NUnit.Runners.2.6.4/tools/nunit-console.exe src/{{{packageName}}}.Test/bin/Debug/{{{packageName}}}.Test.dll
+    mono ./packages/NUnit.Runners.2.6.4/tools/nunit-console.exe {{sourceFolder}}/{{{packageName}}}.Test/bin/Debug/{{{packageName}}}.Test.dll

--- a/src/test/java/io/swagger/codegen/v3/generators/dotnet/CSharpClientCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/dotnet/CSharpClientCodegenTest.java
@@ -1,6 +1,7 @@
 package io.swagger.codegen.v3.generators.dotnet;
 
 import io.swagger.codegen.v3.CodegenConfig;
+import io.swagger.codegen.v3.CodegenConstants;
 import io.swagger.codegen.v3.CodegenModel;
 import io.swagger.codegen.v3.ISchemaHandler;
 import io.swagger.codegen.v3.generators.AbstractCodegenTest;
@@ -58,4 +59,39 @@ public class CSharpClientCodegenTest extends AbstractCodegenTest {
         codegenModel = codegenWrapper.getAllModels().get("ModelList");
         Assert.assertNotNull(codegenModel);
     }
+
+    @Test
+    public void testProcessOpts_WithExplicitSourceFolder() {
+        // Arrange
+        AbstractCSharpCodegen codegen = new CSharpClientCodegen();
+        String expectedCustomFolder = "custom_src_directory";
+
+        // Pass the explicit key configuration
+        codegen.additionalProperties().put(CodegenConstants.SOURCE_FOLDER, expectedCustomFolder);
+
+        // Act
+        codegen.processOpts();
+
+        // Assert: Verify your single-line logical bindings hold true
+        Assert.assertEquals(codegen.getSourceFolder(), expectedCustomFolder, "sourceFolder should be updated via explicit option.");
+        Assert.assertEquals(codegen.getTestFolder(), expectedCustomFolder, "testFolder should explicitly match sourceFolder values when custom defined.");
+    }
+
+    @Test
+    public void testProcessOpts_WithDefaultSourceFolder() {
+        // Arrange
+        AbstractCSharpCodegen codegen = new CSharpClientCodegen();
+
+        // Ensure the option is completely absent from execution properties
+        codegen.additionalProperties().remove(CodegenConstants.SOURCE_FOLDER);
+        String fallbackValue = codegen.sourceFolder; // Capture initial setup default
+
+        // Act
+        codegen.processOpts();
+
+        // Assert: Ensure properties dictionary falls back gracefully
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.SOURCE_FOLDER), fallbackValue, "Properties must append default placeholder context.");
+    }
+
+
 }


### PR DESCRIPTION
## Description

Specified sourceFolder value doesn't properly propagate to test directory.
After my changes the source folder change is reflected entire generated project as expected.


Fixes: [issue 12751](https://github.com/swagger-api/swagger-codegen/issues/12751) in swagger-codegen repo

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [X] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [X] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [X] The PR title is descriptive
- [X] The code builds and passes tests locally
- [X] I have linked related issues (if any)

## How to Test

I have source code for both the repo `swagger-codegen-generators` and `swagger-codegen`. Along with that the issue page have 2 files provided which are `CodeCofig.json` and `test.yaml`

```bash
cd swagger-codegen-generators
mvn clean install
cd ../swagger-codegen
mvn clean package
cd ..
rm -rf bug-12751/code-debug
java -jar swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -l csharp -i bug-12751/test.yaml -c bug-12751/CodeConfig.json -o bug-12751/code-debug
 cd bug-12751/code-debug/
dotnet build
```