### PR TITLE
Fix outer enum generation on jaxrs-resteasy-eap

### DIFF
--- a/src/main/resources/handlebars/JavaJaxRS/resteasy/eap/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/resteasy/eap/enumOuterClass.mustache
@@ -1,7 +1,23 @@
-public enum {{classname}} {
-  {{#allowableValues}}
-  {{#enumVars}}
-  {{{name}}}{{^@last}},{{/@last}}{{#@last}};{{/@last}}
-  {{/enumVars}}
-  {{/allowableValues}}
+/**
+* {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
+*/
+public enum {{#datatypeWithEnum}}{{.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {
+    {{#allowableValues}}
+    {{#enumVars}}
+    {{{name}}}({{#value}}{{{value}}}{{/value}}{{^value}}null{{/value}}){{^@last}},
+{{/@last}}{{#@last}};
+    {{/@last}}
+    {{/enumVars}}
+    {{/allowableValues}}
+    private {{dataType}} value;
+
+    {{#datatypeWithEnum}}{{.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}({{dataType}} value) {
+      this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+      return String.valueOf(value);
+    }
 }

--- a/src/main/resources/handlebars/JavaJaxRS/resteasy/enumOuterClass.mustache
+++ b/src/main/resources/handlebars/JavaJaxRS/resteasy/enumOuterClass.mustache
@@ -1,4 +1,4 @@
-/** o.O
+/**
 * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
 */
 public enum {{#datatypeWithEnum}}{{.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {

--- a/src/test/java/io/swagger/codegen/v3/generators/java/JavaResteasyOuterEnumCodegenTest.java
+++ b/src/test/java/io/swagger/codegen/v3/generators/java/JavaResteasyOuterEnumCodegenTest.java
@@ -1,0 +1,65 @@
+package io.swagger.codegen.v3.generators.java;
+
+import io.swagger.codegen.v3.ClientOptInput;
+import io.swagger.codegen.v3.DefaultGenerator;
+import io.swagger.codegen.v3.config.CodegenConfigurator;
+import io.swagger.codegen.v3.generators.AbstractCodegenTest;
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class JavaResteasyOuterEnumCodegenTest extends AbstractCodegenTest {
+
+    private TemporaryFolder folder = null;
+
+    @Before
+    public void setUp() throws Exception {
+        folder = new TemporaryFolder();
+        folder.create();
+    }
+
+    @After
+    public void tearDown() {
+        folder.delete();
+    }
+
+    @Test
+    public void testOuterEnumResteasy() throws IOException {
+        generateAndAssertOuterEnum("jaxrs-resteasy");
+    }
+
+    @Test
+    public void testOuterEnumResteasyEap() throws IOException {
+        generateAndAssertOuterEnum("jaxrs-resteasy-eap");
+    }
+
+    private void generateAndAssertOuterEnum(String language) throws IOException {
+        final File output = folder.getRoot();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setLang(language)
+            .setInputSpecURL("src/test/resources/3_0_0/outer_enum.yaml")
+            .setOutputDir(output.getAbsolutePath());
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        new DefaultGenerator().opts(clientOptInput).generate();
+
+        final File outerEnumFile = new File(output, "src/gen/java/io/swagger/model/OrderStatus.java");
+        Assert.assertTrue(language + ": OrderStatus.java not generated", outerEnumFile.exists());
+        final String content = FileUtils.readFileToString(outerEnumFile);
+
+        Assert.assertTrue(language, content.contains("import com.fasterxml.jackson.annotation.JsonValue;"));
+        Assert.assertTrue(language, content.contains("public enum OrderStatus {"));
+        Assert.assertTrue(language, content.contains("PLACED(\"placed\")"));
+        Assert.assertTrue(language, content.contains("APPROVED(\"approved\")"));
+        Assert.assertTrue(language, content.contains("DELIVERED(\"delivered\")"));
+        Assert.assertTrue(language, content.contains("private String value;"));
+        Assert.assertTrue(language, content.contains("OrderStatus(String value) {"));
+        Assert.assertTrue(language, content.contains("@JsonValue"));
+    }
+}

--- a/src/test/resources/3_0_0/outer_enum.yaml
+++ b/src/test/resources/3_0_0/outer_enum.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Outer enum generation
+  version: 1.0.0
+paths:
+  /orders/{orderId}/status:
+    get:
+      operationId: getOrderStatus
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderStatus'
+components:
+  schemas:
+    OrderStatus:
+      type: string
+      description: Status of the order
+      enum:
+        - placed
+        - approved
+        - delivered
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/OrderStatus'


### PR DESCRIPTION
### Description of the PR

Top-level (outer) enums generated by **`jaxrs-resteasy-eap`** currently lose their spec values: the generated enum has no value field and no `@JsonValue`, so Jackson serializes the Java constant name (`PLACED`) instead of the wire value (`placed`), breaking round-tripping with any conforming client. Reproducible with a minimal schema:

```yaml
OrderStatus:
  type: string
  enum: [placed, approved, delivered]
```

The sibling `jaxrs-resteasy` template (`handlebars/JavaJaxRS/resteasy/enumOuterClass.mustache`) was already fixed at some point — this PR aligns the `eap` template with it.

Notably, `JavaResteasyEapServerCodegen` already adds the `com.fasterxml.jackson.annotation.JsonValue` import for outer enum models in `postProcessModelsEnum`, so until now the generated file even carried an **unused import**: the template was the missing half, and this PR completes it.

Changes:
- `resteasy/eap/enumOuterClass.mustache`: generate outer enums with value constructor and `@JsonValue`-annotated `toString()`, same as the plain resteasy template
- `resteasy/enumOuterClass.mustache`: remove a stray `o.O` typo in the javadoc opening that ends up verbatim in every generated outer enum
- Added a regression test (`JavaResteasyOuterEnumCodegenTest`) covering both `jaxrs-resteasy` and `jaxrs-resteasy-eap`; it fails on current master for `jaxrs-resteasy-eap` and passes with this PR. The test uses JUnit 4 annotations so it actually runs with the surefire provider configured in the pom.

This is the OAS3 counterpart of swagger-api/swagger-codegen#10533 (same fix for the v2 generators, see also #3856 for the original jaxrs-spec issue).

cc @ewaostrowska 